### PR TITLE
Vrf integration

### DIFF
--- a/crypto/ed25519/extra25519/extra25519_test.go
+++ b/crypto/ed25519/extra25519/extra25519_test.go
@@ -22,7 +22,6 @@ func TestCurve25519Conversion(t *testing.T) {
 	var privBytes [64]byte
 	copy(privBytes[:], private)
 
-
 	var curve25519Public, curve25519Public2, curve25519Private [32]byte
 	PrivateKeyToCurve25519(&curve25519Private, &privBytes)
 	curve25519.ScalarBaseMult(&curve25519Public, &curve25519Private)

--- a/crypto/vrf/vrf.go
+++ b/crypto/vrf/vrf.go
@@ -26,6 +26,7 @@ import (
 
 	"github.com/coniks-sys/coniks-go/crypto/ed25519/edwards25519"
 	"github.com/coniks-sys/coniks-go/crypto/ed25519/extra25519"
+	"golang.org/x/crypto/ed25519"
 )
 
 const (
@@ -56,6 +57,10 @@ func GenerateKey(rnd io.Reader) (pk []byte, sk *[SecretKeySize]byte, err error) 
 
 	copy(sk[32:], pkBytes[:])
 	return pkBytes[:], sk, err
+}
+
+func Public(sk *[SecretKeySize]byte) []byte {
+	return ed25519.PrivateKey(sk[:]).Public().(ed25519.PublicKey)
 }
 
 func expandSecret(sk *[SecretKeySize]byte) (x, skhr *[32]byte) {

--- a/crypto/vrf/vrf_test.go
+++ b/crypto/vrf/vrf_test.go
@@ -29,6 +29,18 @@ func TestHonestComplete(t *testing.T) {
 	}
 }
 
+func TestConvertSecretKeyToPublicKey(t *testing.T) {
+	pk, sk, err := GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pkBytes := Public(sk)
+	if !bytes.Equal(pk, pkBytes) {
+		t.Fatal("Couldn't obtain public key.")
+	}
+}
+
 func TestFlipBitForgery(t *testing.T) {
 	pk, sk, err := GenerateKey(nil)
 	if err != nil {

--- a/merkletree/merkletree.go
+++ b/merkletree/merkletree.go
@@ -37,11 +37,10 @@ func NewMerkleTree() (*MerkleTree, error) {
 	return m, nil
 }
 
-func (m *MerkleTree) Get(key string) *AuthenticationPath {
-	lookupIndex := computePrivateIndex(key)
+func (m *MerkleTree) Get(lookupIndex []byte) *AuthenticationPath {
 	lookupIndexBits := util.ToBits(lookupIndex)
 	depth := 0
-	var nodePointer interface{}
+	var nodePointer MerkleNode
 	nodePointer = m.root
 
 	authPath := &AuthenticationPath{
@@ -92,8 +91,7 @@ func (m *MerkleTree) Get(key string) *AuthenticationPath {
 	panic(ErrorInvalidTree)
 }
 
-func (m *MerkleTree) Set(key string, value []byte) error {
-	index := computePrivateIndex(key)
+func (m *MerkleTree) Set(index []byte, key string, value []byte) error {
 
 	// generate random per user salt
 	salt := make([]byte, crypto.HashSizeByte)
@@ -113,16 +111,10 @@ func (m *MerkleTree) Set(key string, value []byte) error {
 	return nil
 }
 
-// Private Index calculation function
-// would be replaced with Ismail's VRF implementation
-func computePrivateIndex(key string) []byte {
-	return crypto.Digest([]byte(key))
-}
-
 func (m *MerkleTree) insertNode(index []byte, toAdd *userLeafNode) {
 	indexBits := util.ToBits(index)
 	depth := 0
-	var nodePointer interface{}
+	var nodePointer MerkleNode
 	nodePointer = m.root
 
 insertLoop:
@@ -189,6 +181,30 @@ insertLoop:
 		default:
 			panic(ErrorInvalidTree)
 		}
+	}
+}
+
+// visits all leaf-nodes and calls callBack on each of them
+// doesn't modify the underlying tree m
+func (m *MerkleTree) visitLeafNodes(callBack func(*userLeafNode)) {
+	visitULNsInternal(m.root, callBack)
+}
+
+func visitULNsInternal(nodePtr MerkleNode, callBack func(*userLeafNode)) {
+	switch nodePtr.(type) {
+	case *userLeafNode:
+		callBack(nodePtr.(*userLeafNode))
+	case *interiorNode:
+		if leftChild := nodePtr.(*interiorNode).leftChild; leftChild != nil {
+			visitULNsInternal(leftChild, callBack)
+		}
+		if rightChild := nodePtr.(*interiorNode).rightChild; rightChild != nil {
+			visitULNsInternal(rightChild, callBack)
+		}
+	case *emptyNode:
+		// do nothing
+	default:
+		panic(ErrorInvalidTree)
 	}
 }
 

--- a/merkletree/pad.go
+++ b/merkletree/pad.go
@@ -2,9 +2,11 @@ package merkletree
 
 import (
 	"crypto/rand"
+	"crypto/subtle"
 	"errors"
 
 	"github.com/coniks-sys/coniks-go/crypto"
+	"github.com/coniks-sys/coniks-go/crypto/vrf"
 )
 
 var (
@@ -15,10 +17,11 @@ var (
 // PAD is an acronym for persistent authenticated dictionary
 type PAD struct {
 	key          crypto.SigningKey
-	tree         *MerkleTree
+	tree         *MerkleTree // will be used to create the next STR
 	snapshots    map[uint64]*SignedTreeRoot
 	loadedEpochs []uint64 // slice of epochs in snapshots
-	currentSTR   *SignedTreeRoot
+	latestSTR    *SignedTreeRoot
+	policies     Policies // the current policies in place
 }
 
 // NewPAD creates new PAD consisting of an array of hash chain
@@ -34,36 +37,46 @@ func NewPAD(policies Policies, key crypto.SigningKey, len uint64) (*PAD, error) 
 	if err != nil {
 		return nil, err
 	}
+	pad.policies = policies
 	pad.snapshots = make(map[uint64]*SignedTreeRoot, len)
 	pad.loadedEpochs = make([]uint64, 0, len)
-	pad.updateInternal(policies, 0)
+	pad.updateInternal(nil, 0)
 	return pad, nil
 }
 
 // if policies is nil, the previous policies will be used
-func (pad *PAD) generateNextSTR(policies Policies, m *MerkleTree, epoch uint64) {
+func (pad *PAD) signTreeRoot(m *MerkleTree, epoch uint64) {
 	var prevStrHash []byte
-	if pad.currentSTR == nil {
+	if pad.latestSTR == nil {
 		prevStrHash = make([]byte, crypto.HashSizeByte)
 		if _, err := rand.Read(prevStrHash); err != nil {
 			// panic here since if there is an error, it will break the PAD.
 			panic(err)
 		}
 	} else {
-		prevStrHash = crypto.Digest(pad.currentSTR.sig)
-		if policies == nil {
-			policies = pad.currentSTR.policies
-		}
+		prevStrHash = crypto.Digest(pad.latestSTR.sig)
 	}
-	pad.currentSTR = NewSTR(pad.key, policies, m, epoch, prevStrHash)
+	pad.latestSTR = NewSTR(pad.key, pad.policies, m, epoch, prevStrHash)
 }
 
 func (pad *PAD) updateInternal(policies Policies, epoch uint64) {
 	pad.tree.recomputeHash()
 	m := pad.tree.Clone()
-	pad.generateNextSTR(policies, m, epoch)
-	pad.snapshots[epoch] = pad.currentSTR
+	// create STR with the policies that were actually used in the prev.
+	// Set() operation
+	pad.signTreeRoot(m, epoch)
+	pad.snapshots[epoch] = pad.latestSTR
 	pad.loadedEpochs = append(pad.loadedEpochs, epoch)
+
+	if policies != nil { // update the policies if necessary
+		vrfKeyChanged := 1 != (subtle.ConstantTimeCompare(
+			pad.policies.vrfPrivate()[:],
+			policies.vrfPrivate()[:]))
+		pad.policies = policies
+		if vrfKeyChanged {
+			pad.reshuffle()
+		}
+	}
 }
 
 func (pad *PAD) Update(policies Policies) {
@@ -76,16 +89,16 @@ func (pad *PAD) Update(policies Policies) {
 		pad.loadedEpochs = append(pad.loadedEpochs[:0], pad.loadedEpochs[n:]...)
 	}
 
-	pad.updateInternal(policies, pad.currentSTR.epoch+1)
+	pad.updateInternal(policies, pad.latestSTR.epoch+1)
 }
 
 func (pad *PAD) Set(key string, value []byte) error {
-	return pad.tree.Set(key, value)
+	index, _ := pad.computePrivateIndex(key, pad.policies.vrfPrivate())
+	return pad.tree.Set(index, key, value)
 }
 
-func (pad *PAD) Lookup(key string) *AuthenticationPath {
-	str := pad.currentSTR
-	return str.tree.Get(key)
+func (pad *PAD) Lookup(key string) (*AuthenticationPath, error) {
+	return pad.LookupInEpoch(key, pad.latestSTR.epoch)
 }
 
 func (pad *PAD) LookupInEpoch(key string, epoch uint64) (*AuthenticationPath, error) {
@@ -93,31 +106,57 @@ func (pad *PAD) LookupInEpoch(key string, epoch uint64) (*AuthenticationPath, er
 	if str == nil {
 		return nil, ErrorSTRNotFound
 	}
-	ap := str.tree.Get(key)
+	lookupIndex, proof := pad.computePrivateIndex(key, str.policies.vrfPrivate())
+	ap := str.tree.Get(lookupIndex)
+	ap.vrfProof = proof
 	return ap, nil
 }
 
 func (pad *PAD) GetSTR(epoch uint64) *SignedTreeRoot {
-	if epoch >= pad.currentSTR.epoch {
-		return pad.currentSTR
+	if epoch >= pad.latestSTR.epoch {
+		return pad.latestSTR
 	}
 	return pad.snapshots[epoch]
 }
 
 func (pad *PAD) TB(key string, value []byte) (*TemporaryBinding, error) {
-	//FIXME: compute private index twice
-	//it would be refactored after merging VRF integration branch
-	index := computePrivateIndex(key)
-	tb := pad.currentSTR.sig
+	str := pad.latestSTR
+	index, _ := pad.computePrivateIndex(key, pad.policies.vrfPrivate())
+	tb := str.sig
 	tb = append(tb, index...)
 	tb = append(tb, value...)
 	sig := crypto.Sign(pad.key, tb)
 
-	err := pad.Set(key, value)
+	err := pad.tree.Set(index, key, value)
 
 	return &TemporaryBinding{
 		index: index,
 		value: value,
 		sig:   sig,
 	}, err
+}
+
+// reshuffle recomputes indices of keys and store them with their values in new
+// tree with new new position;
+// swaps pad.tree if everything worked out.
+// if there is any error on the way (lack of entropy for randomness) reshuffle
+// will panic
+func (pad *PAD) reshuffle() {
+	newTree, err := NewMerkleTree()
+	if err != nil {
+		panic(err)
+	}
+	pad.tree.visitLeafNodes(func(n *userLeafNode) {
+		newIndex, _ := pad.computePrivateIndex(n.key, pad.policies.vrfPrivate())
+		if err := newTree.Set(newIndex, n.key, n.value); err != nil {
+			panic(err)
+		}
+	})
+	pad.tree = newTree
+}
+
+func (pad *PAD) computePrivateIndex(key string,
+	vrfPrivKey *[vrf.SecretKeySize]byte) (index, proof []byte) {
+	index, proof = vrf.Prove([]byte(key), vrfPrivKey)
+	return
 }

--- a/merkletree/policy.go
+++ b/merkletree/policy.go
@@ -2,6 +2,7 @@ package merkletree
 
 import (
 	"github.com/coniks-sys/coniks-go/crypto"
+	"github.com/coniks-sys/coniks-go/crypto/vrf"
 	"github.com/coniks-sys/coniks-go/utils"
 )
 
@@ -10,17 +11,20 @@ type TimeStamp uint64
 type Policies interface {
 	EpochDeadline() TimeStamp
 	Serialize() []byte
+	vrfPrivate() *[vrf.SecretKeySize]byte
 }
 
 type DefaultPolicies struct {
+	vrfPrivateKey *[vrf.SecretKeySize]byte
 	epochDeadline TimeStamp
 }
 
 var _ Policies = (*DefaultPolicies)(nil)
 
-func NewPolicies(epDeadline TimeStamp) Policies {
+func NewPolicies(epDeadline TimeStamp, vrfPrivKey *[vrf.SecretKeySize]byte) Policies {
 	return &DefaultPolicies{
 		epochDeadline: epDeadline,
+		vrfPrivateKey: vrfPrivKey,
 	}
 }
 
@@ -31,7 +35,12 @@ func (p *DefaultPolicies) Serialize() []byte {
 	bs = append(bs, []byte(Version)...)                            // lib Version
 	bs = append(bs, []byte(crypto.HashID)...)                      // cryptographic algorithms in use
 	bs = append(bs, util.ULongToBytes(uint64(p.epochDeadline))...) // epoch deadline
+	bs = append(bs, vrf.Public(p.vrfPrivateKey)...)                // vrf public key
 	return bs
+}
+
+func (p *DefaultPolicies) vrfPrivate() *[vrf.SecretKeySize]byte {
+	return p.vrfPrivateKey
 }
 
 func (p *DefaultPolicies) EpochDeadline() TimeStamp {

--- a/merkletree/proof.go
+++ b/merkletree/proof.go
@@ -4,6 +4,7 @@ type AuthenticationPath struct {
 	treeNonce    []byte
 	prunedHashes [][]byte
 	lookupIndex  []byte
+	vrfProof     []byte
 	leaf         ProofNode
 }
 
@@ -17,6 +18,10 @@ func (ap *AuthenticationPath) PrunedTree() [][]byte {
 
 func (ap *AuthenticationPath) LookupIndex() []byte {
 	return ap.lookupIndex
+}
+
+func (ap *AuthenticationPath) VrfProof() []byte {
+	return ap.vrfProof
 }
 
 func (ap *AuthenticationPath) Leaf() ProofNode {


### PR DESCRIPTION
Use coname's vrf implementation to compute the private index
- Should resolve #14 
- commented out parts of a test which is supposed to work with a specific hash (but not with vrf); might be changed with #16 and #18
- replaced `t.Error` in combination with `return` with `t.Fatal`