### PR TITLE
Add proof for STRs and TBs

### DIFF
--- a/merkletree/pad.go
+++ b/merkletree/pad.go
@@ -116,6 +116,7 @@ func (pad *PAD) TB(key string, value []byte) (*TemporaryBinding, error) {
 	err := pad.Set(key, value)
 
 	return &TemporaryBinding{
+		str:   pad.currentSTR.sig,
 		index: index,
 		value: value,
 		sig:   sig,

--- a/merkletree/str.go
+++ b/merkletree/str.go
@@ -79,3 +79,15 @@ func (str *SignedTreeRoot) PreviousSTRHash() []byte {
 func (str *SignedTreeRoot) Signature() []byte {
 	return str.sig
 }
+
+func (str *SignedTreeRoot) LibVersion() []byte {
+	return []byte(Version)
+}
+
+func (str *SignedTreeRoot) HashID() []byte {
+	return []byte(crypto.HashID)
+}
+
+func (str *SignedTreeRoot) EpochDeadlinePolicy() []byte {
+	return util.ULongToBytes(uint64(str.policies.EpochDeadline()))
+}

--- a/merkletree/tb.go
+++ b/merkletree/tb.go
@@ -1,6 +1,7 @@
 package merkletree
 
 type TemporaryBinding struct {
+	str   []byte
 	index []byte
 	value []byte
 	sig   []byte
@@ -16,4 +17,8 @@ func (tb *TemporaryBinding) Value() []byte {
 
 func (tb *TemporaryBinding) Signature() []byte {
 	return tb.sig
+}
+
+func (tb *TemporaryBinding) STR() []byte {
+	return tb.str
 }


### PR DESCRIPTION
* Resolve #24

* The `TB` also publishes the `IndexProof` after `vrf_integration` branch is merged.