### PR TITLE
Remove all getters

### DIFF
--- a/merkletree/merkletree.go
+++ b/merkletree/merkletree.go
@@ -44,8 +44,8 @@ func (m *MerkleTree) Get(lookupIndex []byte) *AuthenticationPath {
 	nodePointer = m.root
 
 	authPath := &AuthenticationPath{
-		treeNonce:   m.nonce,
-		lookupIndex: lookupIndex,
+		TreeNonce:   m.nonce,
+		LookupIndex: lookupIndex,
 	}
 
 	for {
@@ -59,11 +59,11 @@ func (m *MerkleTree) Get(lookupIndex []byte) *AuthenticationPath {
 		}
 		direction := lookupIndexBits[depth]
 		if direction {
-			authPath.prunedHashes = append(authPath.prunedHashes,
+			authPath.PrunedTree = append(authPath.PrunedTree,
 				nodePointer.(*interiorNode).leftHash)
 			nodePointer = nodePointer.(*interiorNode).rightChild
 		} else {
-			authPath.prunedHashes = append(authPath.prunedHashes,
+			authPath.PrunedTree = append(authPath.PrunedTree,
 				nodePointer.(*interiorNode).rightHash)
 			nodePointer = nodePointer.(*interiorNode).leftChild
 		}
@@ -76,7 +76,7 @@ func (m *MerkleTree) Get(lookupIndex []byte) *AuthenticationPath {
 	switch nodePointer.(type) {
 	case *userLeafNode:
 		pNode := nodePointer.(*userLeafNode).Clone(nil).(*userLeafNode)
-		authPath.leaf = pNode
+		authPath.Leaf = pNode
 		if bytes.Equal(nodePointer.(*userLeafNode).index, lookupIndex) {
 			return authPath
 		}
@@ -85,7 +85,7 @@ func (m *MerkleTree) Get(lookupIndex []byte) *AuthenticationPath {
 		pNode.value = nil
 		return authPath
 	case *emptyNode:
-		authPath.leaf = nodePointer.(*emptyNode).Clone(nil).(*emptyNode)
+		authPath.Leaf = nodePointer.(*emptyNode).Clone(nil).(*emptyNode)
 		return authPath
 	}
 	panic(ErrorInvalidTree)
@@ -210,10 +210,6 @@ func visitULNsInternal(nodePtr MerkleNode, callBack func(*userLeafNode)) {
 
 func (m *MerkleTree) recomputeHash() {
 	m.hash = m.root.Hash(m)
-}
-
-func (m *MerkleTree) GetHash() []byte {
-	return m.hash
 }
 
 func (m *MerkleTree) Clone() *MerkleTree {

--- a/merkletree/merkletree_test.go
+++ b/merkletree/merkletree_test.go
@@ -46,18 +46,18 @@ func TestOneEntry(t *testing.T) {
 	}
 
 	r := m.Get(index)
-	if r.Leaf().Value() == nil {
+	if r.Leaf.Value() == nil {
 		t.Error("Cannot find value of key:", key)
 		return
 	}
-	v := r.Leaf().Value()
+	v := r.Leaf.Value()
 	if !bytes.Equal(v, val) {
 		t.Errorf("Value mismatch %v / %v", v, val)
 	}
 
 	// Check leaf node hash
 	h.Reset()
-	h.Write(r.Leaf().(*userLeafNode).salt)
+	h.Write(r.Leaf.(*userLeafNode).salt)
 	h.Write([]byte(key))
 	h.Write(val)
 	h.Read(commit[:])
@@ -77,7 +77,7 @@ func TestOneEntry(t *testing.T) {
 	}
 
 	r = m.Get([]byte("abc"))
-	if r.Leaf().Value() != nil {
+	if r.Leaf.Value() != nil {
 		t.Error("Invalid look-up operation:", key)
 		return
 	}
@@ -104,21 +104,21 @@ func TestTwoEntries(t *testing.T) {
 	}
 
 	ap1 := m.Get(index1)
-	if ap1.Leaf().Value() == nil {
+	if ap1.Leaf.Value() == nil {
 		t.Error("Cannot find key:", key1)
 		return
 	}
 
 	ap2 := m.Get(index2)
-	if ap2.Leaf().Value() == nil {
+	if ap2.Leaf.Value() == nil {
 		t.Error("Cannot find key:", key2)
 		return
 	}
 
-	if !bytes.Equal(ap1.Leaf().Value(), []byte("value1")) {
+	if !bytes.Equal(ap1.Leaf.Value(), []byte("value1")) {
 		t.Error(key1, "value mismatch")
 	}
-	if !bytes.Equal(ap2.Leaf().Value(), []byte("value2")) {
+	if !bytes.Equal(ap2.Leaf.Value(), []byte("value2")) {
 		t.Error(key2, "value mismatch")
 	}
 }
@@ -150,42 +150,42 @@ func TestThreeEntries(t *testing.T) {
 	}
 
 	ap1 := m.Get(index1)
-	if ap1.Leaf().Value() == nil {
+	if ap1.Leaf.Value() == nil {
 		t.Error("Cannot find key:", index1)
 		return
 	}
 	ap2 := m.Get(index2)
-	if ap2.Leaf().Value() == nil {
+	if ap2.Leaf.Value() == nil {
 		t.Error("Cannot find key:", index2)
 		return
 	}
 	ap3 := m.Get(index3)
-	if ap3.Leaf().Value() == nil {
+	if ap3.Leaf.Value() == nil {
 		t.Error("Cannot find key:", index3)
 		return
 	}
 	/*
 		// since the first bit of ap2 index is false and the one of ap1 & ap3 are true
-		if ap2.Leaf().Level() != 1 {
+		if ap2.Leaf.Level() != 1 {
 			t.Error("Malformed tree insertion")
 		}
 
 		// since n1 and n3 share first 2 bits
-		if ap1.Leaf().Level() != 3 {
+		if ap1.Leaf.Level() != 3 {
 			t.Error("Malformed tree insertion")
 		}
-		if ap3.Leaf().Level() != 3 {
+		if ap3.Leaf.Level() != 3 {
 			t.Error("Malformed tree insertion")
 		}
 	*/
 
-	if !bytes.Equal(ap1.Leaf().Value(), []byte("value1")) {
+	if !bytes.Equal(ap1.Leaf.Value(), []byte("value1")) {
 		t.Error(key1, "value mismatch")
 	}
-	if !bytes.Equal(ap2.Leaf().Value(), []byte("value2")) {
+	if !bytes.Equal(ap2.Leaf.Value(), []byte("value2")) {
 		t.Error(key2, "value mismatch")
 	}
-	if !bytes.Equal(ap3.Leaf().Value(), []byte("value3")) {
+	if !bytes.Equal(ap3.Leaf.Value(), []byte("value3")) {
 		t.Error(key3, "value mismatch")
 	}
 }
@@ -210,17 +210,17 @@ func TestInsertExistedKey(t *testing.T) {
 	}
 
 	ap := m.Get(index1)
-	if ap.Leaf().Value() == nil {
+	if ap.Leaf.Value() == nil {
 		t.Error("Cannot find key:", key1)
 		return
 	}
 
-	if !bytes.Equal(ap.Leaf().Value(), []byte("new value")) {
+	if !bytes.Equal(ap.Leaf.Value(), []byte("new value")) {
 		t.Error(index1, "value mismatch\n")
 	}
 
-	if !bytes.Equal(ap.Leaf().Value(), val2) {
-		t.Errorf("Value mismatch %v / %v", ap.Leaf().Value(), val2)
+	if !bytes.Equal(ap.Leaf.Value(), val2) {
+		t.Errorf("Value mismatch %v / %v", ap.Leaf.Value(), val2)
 	}
 
 	val3 := []byte("new value 2")
@@ -229,13 +229,13 @@ func TestInsertExistedKey(t *testing.T) {
 	}
 
 	ap = m.Get(index1)
-	if ap.Leaf().Value() == nil {
+	if ap.Leaf.Value() == nil {
 		t.Error("Cannot find key:", key1)
 		return
 	}
 
-	if !bytes.Equal(ap.Leaf().Value(), val3) {
-		t.Errorf("Value mismatch %v / %v", ap.Leaf().Value(), val3)
+	if !bytes.Equal(ap.Leaf.Value(), val3) {
+		t.Errorf("Value mismatch %v / %v", ap.Leaf.Value(), val3)
 	}
 }
 
@@ -276,20 +276,20 @@ func TestTreeClone(t *testing.T) {
 
 	// lookup
 	ap := m2.Get(index1)
-	if ap.Leaf().Value() == nil {
+	if ap.Leaf.Value() == nil {
 		t.Error("Cannot find key:", key1)
 		return
 	}
-	if !bytes.Equal(ap.Leaf().Value(), []byte("value1")) {
+	if !bytes.Equal(ap.Leaf.Value(), []byte("value1")) {
 		t.Error(key1, "value mismatch\n")
 	}
 
 	ap = m2.Get(index2)
-	if ap.Leaf().Value() == nil {
+	if ap.Leaf.Value() == nil {
 		t.Error("Cannot find key:", key2)
 		return
 	}
-	if !bytes.Equal(ap.Leaf().Value(), []byte("value2")) {
+	if !bytes.Equal(ap.Leaf.Value(), []byte("value2")) {
 		t.Error(key2, "value mismatch\n")
 	}
 }

--- a/merkletree/pad.go
+++ b/merkletree/pad.go
@@ -54,7 +54,7 @@ func (pad *PAD) signTreeRoot(m *MerkleTree, epoch uint64) {
 			panic(err)
 		}
 	} else {
-		prevStrHash = crypto.Digest(pad.latestSTR.sig)
+		prevStrHash = crypto.Digest(pad.latestSTR.Signature)
 	}
 	pad.latestSTR = NewSTR(pad.key, pad.policies, m, epoch, prevStrHash)
 }
@@ -89,7 +89,7 @@ func (pad *PAD) Update(policies Policies) {
 		pad.loadedEpochs = append(pad.loadedEpochs[:0], pad.loadedEpochs[n:]...)
 	}
 
-	pad.updateInternal(policies, pad.latestSTR.epoch+1)
+	pad.updateInternal(policies, pad.latestSTR.Epoch+1)
 }
 
 func (pad *PAD) Set(key string, value []byte) error {
@@ -98,7 +98,7 @@ func (pad *PAD) Set(key string, value []byte) error {
 }
 
 func (pad *PAD) Lookup(key string) (*AuthenticationPath, error) {
-	return pad.LookupInEpoch(key, pad.latestSTR.epoch)
+	return pad.LookupInEpoch(key, pad.latestSTR.Epoch)
 }
 
 func (pad *PAD) LookupInEpoch(key string, epoch uint64) (*AuthenticationPath, error) {
@@ -106,14 +106,14 @@ func (pad *PAD) LookupInEpoch(key string, epoch uint64) (*AuthenticationPath, er
 	if str == nil {
 		return nil, ErrorSTRNotFound
 	}
-	lookupIndex, proof := pad.computePrivateIndex(key, str.policies.vrfPrivate())
+	lookupIndex, proof := pad.computePrivateIndex(key, str.Policies.vrfPrivate())
 	ap := str.tree.Get(lookupIndex)
-	ap.vrfProof = proof
+	ap.VrfProof = proof
 	return ap, nil
 }
 
 func (pad *PAD) GetSTR(epoch uint64) *SignedTreeRoot {
-	if epoch >= pad.latestSTR.epoch {
+	if epoch >= pad.latestSTR.Epoch {
 		return pad.latestSTR
 	}
 	return pad.snapshots[epoch]
@@ -122,7 +122,7 @@ func (pad *PAD) GetSTR(epoch uint64) *SignedTreeRoot {
 func (pad *PAD) TB(key string, value []byte) (*TemporaryBinding, error) {
 	str := pad.latestSTR
 	index, _ := pad.computePrivateIndex(key, pad.policies.vrfPrivate())
-	tb := str.sig
+	tb := str.Signature
 	tb = append(tb, index...)
 	tb = append(tb, value...)
 	sig := crypto.Sign(pad.key, tb)
@@ -130,9 +130,9 @@ func (pad *PAD) TB(key string, value []byte) (*TemporaryBinding, error) {
 	err := pad.tree.Set(index, key, value)
 
 	return &TemporaryBinding{
-		index: index,
-		value: value,
-		sig:   sig,
+		Index:     index,
+		Value:     value,
+		Signature: sig,
 	}, err
 }
 

--- a/merkletree/pad_test.go
+++ b/merkletree/pad_test.go
@@ -66,8 +66,8 @@ func TestPADHashChain(t *testing.T) {
 			t.Fatal("Malformed PAD Update")
 		}
 
-		if str.epoch != uint64(i) {
-			t.Fatal("Got invalid STR", "want", i, "got", str.epoch)
+		if str.Epoch != uint64(i) {
+			t.Fatal("Got invalid STR", "want", i, "got", str.Epoch)
 		}
 	}
 
@@ -76,62 +76,62 @@ func TestPADHashChain(t *testing.T) {
 		t.Error("Cannot get STR")
 	}
 
-	if str.epoch != 3 {
-		t.Error("Got invalid STR", "want", 3, "got", str.epoch)
+	if str.Epoch != 3 {
+		t.Error("Got invalid STR", "want", 3, "got", str.Epoch)
 	}
 
 	// lookup
 	ap, _ := pad.Lookup(key1)
-	if ap.Leaf().Value() == nil {
+	if ap.Leaf.Value() == nil {
 		t.Error("Cannot find key:", key1)
 		return
 	}
-	if !bytes.Equal(ap.Leaf().Value(), val1) {
+	if !bytes.Equal(ap.Leaf.Value(), val1) {
 		t.Error(key1, "value mismatch")
 	}
 
 	ap, _ = pad.Lookup(key2)
-	if ap.Leaf().Value() == nil {
+	if ap.Leaf.Value() == nil {
 		t.Error("Cannot find key:", key2)
 		return
 	}
-	if !bytes.Equal(ap.Leaf().Value(), val2) {
+	if !bytes.Equal(ap.Leaf.Value(), val2) {
 		t.Error(key2, "value mismatch")
 	}
 
 	ap, _ = pad.Lookup(key3)
-	if ap.Leaf().Value() == nil {
+	if ap.Leaf.Value() == nil {
 		t.Error("Cannot find key:", key3)
 		return
 	}
-	if !bytes.Equal(ap.Leaf().Value(), val3) {
+	if !bytes.Equal(ap.Leaf.Value(), val3) {
 		t.Error(key3, "value mismatch")
 	}
 
 	ap, err = pad.LookupInEpoch(key2, 1)
 	if err != nil {
 		t.Error(err)
-	} else if ap.Leaf().Value() != nil {
+	} else if ap.Leaf.Value() != nil {
 		t.Error("Found unexpected key", key2, "in STR #", 1)
 	}
 	ap, err = pad.LookupInEpoch(key2, 2)
 	if err != nil {
 		t.Error(err)
-	} else if ap.Leaf().Value() == nil {
+	} else if ap.Leaf.Value() == nil {
 		t.Error("Cannot find key", key2, "in STR #", 2)
 	}
 
 	ap, err = pad.LookupInEpoch(key3, 2)
 	if err != nil {
 		t.Error(err)
-	} else if ap.Leaf().Value() != nil {
+	} else if ap.Leaf.Value() != nil {
 		t.Error("Found unexpected key", key3, "in STR #", 2)
 	}
 
 	ap, err = pad.LookupInEpoch(key3, 3)
 	if err != nil {
 		t.Error(err)
-	} else if ap.Leaf().Value() == nil {
+	} else if ap.Leaf.Value() == nil {
 		t.Error("Cannot find key", key3, "in STR #", 3)
 	}
 }
@@ -201,25 +201,25 @@ func TestPoliciesChange(t *testing.T) {
 	pad.Update(nil)
 
 	ap, _ := pad.Lookup(key1)
-	if ap.Leaf().Value() == nil {
+	if ap.Leaf.Value() == nil {
 		t.Error("Cannot find key:", key1)
 	}
-	if !bytes.Equal(ap.Leaf().Value(), val1) {
+	if !bytes.Equal(ap.Leaf.Value(), val1) {
 		t.Error(key1, "value mismatch")
 	}
 
 	ap, _ = pad.Lookup(key2)
-	if ap.Leaf().Value() == nil {
+	if ap.Leaf.Value() == nil {
 		t.Error("Cannot find key:", key2)
 	}
-	if !bytes.Equal(ap.Leaf().Value(), val2) {
+	if !bytes.Equal(ap.Leaf.Value(), val2) {
 		t.Error(key2, "value mismatch")
 	}
 
 	ap, err = pad.LookupInEpoch(key1, 1)
 	if err != nil {
 		t.Error(err)
-	} else if !bytes.Equal(ap.Leaf().Value(), val1) {
+	} else if !bytes.Equal(ap.Leaf.Value(), val1) {
 		t.Error(key1, "value mismatch")
 	}
 	ap, err = pad.LookupInEpoch(key2, 2)
@@ -229,9 +229,9 @@ func TestPoliciesChange(t *testing.T) {
 	ap, err = pad.LookupInEpoch(key3, 3)
 	if err != nil {
 		t.Error(err)
-	} else if ap.Leaf().Value() == nil {
+	} else if ap.Leaf.Value() == nil {
 		t.Error("Cannot find key", key3, "in STR #", 3)
-	} else if !bytes.Equal(ap.Leaf().Value(), val3) {
+	} else if !bytes.Equal(ap.Leaf.Value(), val3) {
 		t.Error(key3, "value mismatch")
 	}
 }

--- a/merkletree/policy.go
+++ b/merkletree/policy.go
@@ -9,21 +9,20 @@ import (
 type TimeStamp uint64
 
 type Policies interface {
-	EpochDeadline() TimeStamp
 	Serialize() []byte
 	vrfPrivate() *[vrf.SecretKeySize]byte
 }
 
 type ConiksPolicies struct {
 	vrfPrivateKey *[vrf.SecretKeySize]byte
-	epochDeadline TimeStamp
+	EpochDeadline TimeStamp
 }
 
 var _ Policies = (*ConiksPolicies)(nil)
 
 func NewPolicies(epDeadline TimeStamp, vrfPrivKey *[vrf.SecretKeySize]byte) Policies {
 	return &ConiksPolicies{
-		epochDeadline: epDeadline,
+		EpochDeadline: epDeadline,
 		vrfPrivateKey: vrfPrivKey,
 	}
 }
@@ -34,15 +33,11 @@ func (p *ConiksPolicies) Serialize() []byte {
 	var bs []byte
 	bs = append(bs, []byte(Version)...)                            // lib Version
 	bs = append(bs, []byte(crypto.HashID)...)                      // cryptographic algorithms in use
-	bs = append(bs, util.ULongToBytes(uint64(p.epochDeadline))...) // epoch deadline
+	bs = append(bs, util.ULongToBytes(uint64(p.EpochDeadline))...) // epoch deadline
 	bs = append(bs, vrf.Public(p.vrfPrivateKey)...)                // vrf public key
 	return bs
 }
 
 func (p *ConiksPolicies) vrfPrivate() *[vrf.SecretKeySize]byte {
 	return p.vrfPrivateKey
-}
-
-func (p *ConiksPolicies) EpochDeadline() TimeStamp {
-	return p.epochDeadline
 }

--- a/merkletree/proof.go
+++ b/merkletree/proof.go
@@ -1,31 +1,11 @@
 package merkletree
 
 type AuthenticationPath struct {
-	treeNonce    []byte
-	prunedHashes [][]byte
-	lookupIndex  []byte
-	vrfProof     []byte
-	leaf         ProofNode
-}
-
-func (ap *AuthenticationPath) TreeNonce() []byte {
-	return ap.treeNonce
-}
-
-func (ap *AuthenticationPath) PrunedTree() [][]byte {
-	return ap.prunedHashes
-}
-
-func (ap *AuthenticationPath) LookupIndex() []byte {
-	return ap.lookupIndex
-}
-
-func (ap *AuthenticationPath) VrfProof() []byte {
-	return ap.vrfProof
-}
-
-func (ap *AuthenticationPath) Leaf() ProofNode {
-	return ap.leaf
+	TreeNonce   []byte
+	PrunedTree  [][]byte
+	LookupIndex []byte
+	VrfProof    []byte
+	Leaf        ProofNode
 }
 
 type ProofNode interface {

--- a/merkletree/str.go
+++ b/merkletree/str.go
@@ -18,12 +18,12 @@ var (
 // previous STR, and its signature.
 // STR should be final
 type SignedTreeRoot struct {
-	tree        *MerkleTree
-	epoch       uint64
-	prevEpoch   uint64
-	prevStrHash []byte
-	sig         []byte
-	policies    Policies
+	tree            *MerkleTree
+	Epoch           uint64
+	PreviousEpoch   uint64
+	PreviousSTRHash []byte
+	Signature       []byte
+	Policies        Policies
 }
 
 func NewSTR(key crypto.SigningKey, policies Policies, m *MerkleTree, epoch uint64, prevHash []byte) *SignedTreeRoot {
@@ -35,14 +35,14 @@ func NewSTR(key crypto.SigningKey, policies Policies, m *MerkleTree, epoch uint6
 		prevEpoch = 0
 	}
 	str := &SignedTreeRoot{
-		tree:        m,
-		epoch:       epoch,
-		prevEpoch:   prevEpoch,
-		prevStrHash: prevHash,
-		policies:    policies,
+		tree:            m,
+		Epoch:           epoch,
+		PreviousEpoch:   prevEpoch,
+		PreviousSTRHash: prevHash,
+		Policies:        policies,
 	}
 	bytesPreSig := str.Serialize()
-	str.sig = crypto.Sign(key, bytesPreSig)
+	str.Signature = crypto.Sign(key, bytesPreSig)
 	return str
 }
 
@@ -50,32 +50,16 @@ func NewSTR(key crypto.SigningKey, policies Policies, m *MerkleTree, epoch uint6
 // [epoch, previous epoch, tree hash, previous STR hash, policies serialization]
 func (str *SignedTreeRoot) Serialize() []byte {
 	var strBytes []byte
-	strBytes = append(strBytes, util.ULongToBytes(str.epoch)...) // t - epoch number
-	if str.epoch > 0 {
-		strBytes = append(strBytes, util.ULongToBytes(str.prevEpoch)...) // t_prev - previous epoch number
+	strBytes = append(strBytes, util.ULongToBytes(str.Epoch)...) // t - epoch number
+	if str.Epoch > 0 {
+		strBytes = append(strBytes, util.ULongToBytes(str.PreviousEpoch)...) // t_prev - previous epoch number
 	}
 	strBytes = append(strBytes, str.tree.hash...)            // root
-	strBytes = append(strBytes, str.prevStrHash...)          // previous STR hash
-	strBytes = append(strBytes, str.policies.Serialize()...) // P
+	strBytes = append(strBytes, str.PreviousSTRHash...)      // previous STR hash
+	strBytes = append(strBytes, str.Policies.Serialize()...) // P
 	return strBytes
 }
 
 func (str *SignedTreeRoot) Root() []byte {
 	return str.tree.hash
-}
-
-func (str *SignedTreeRoot) Epoch() uint64 {
-	return str.epoch
-}
-
-func (str *SignedTreeRoot) PreviousEpoch() uint64 {
-	return str.prevEpoch
-}
-
-func (str *SignedTreeRoot) PreviousSTRHash() []byte {
-	return str.prevStrHash
-}
-
-func (str *SignedTreeRoot) Signature() []byte {
-	return str.sig
 }

--- a/merkletree/tb.go
+++ b/merkletree/tb.go
@@ -1,19 +1,7 @@
 package merkletree
 
 type TemporaryBinding struct {
-	index []byte
-	value []byte
-	sig   []byte
-}
-
-func (tb *TemporaryBinding) Index() []byte {
-	return tb.index
-}
-
-func (tb *TemporaryBinding) Value() []byte {
-	return tb.value
-}
-
-func (tb *TemporaryBinding) Signature() []byte {
-	return tb.sig
+	Index     []byte
+	Value     []byte
+	Signature []byte
 }


### PR DESCRIPTION
~~Golang code should not use getters and setters rather than struct fields.~~ This pull removes all getters from `STR`, `AuthenticationPath`, `TemporaryBinding` and `DefaultPolicies` struct.
/cc @arlolra @masomel @Liamsi 