### PR TITLE
Client library for verifications

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,9 @@
 *.so
 *.dylib
 
+# Cgo compiled headers
+libconiks.h
+
 # Folders
 _obj
 _test

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ hijacking secure communications without getting caught.
 ## Golang Library
 The packages in this library implement the various components of the CONIKS system and may be imported individually.
 
+- ``client``: Client-side protocol cgo hooks
 - ``crypto``: Cryptographic algorithms and operations
 - ``merkletree``: Merkle prefix tree and related data structures
 - ``utils``: Utility functions 

--- a/client/cgo/Makefile
+++ b/client/cgo/Makefile
@@ -1,0 +1,24 @@
+SOURCEDIR=$(pwd)
+SOURCES="verification.go"
+
+NAME=coniks
+
+UNAME := $(shell uname)
+ifeq ($(UNAME),Darwin)
+	LIB_NAME := lib$(NAME).dylib
+else
+	LIB_NAME := lib$(NAME).so
+endif
+
+BUILD_MODE=-buildmode=c-shared
+CFLAGS=
+LDFLAGS=-ldflags "-s -w"
+.DEFAULT_GOAL: $(LIB_NAME)
+
+$(LIB_NAME):
+	go build ${LDFLAGS} ${BUILD_MODE} -o ${LIB_NAME} ${SOURCES}
+
+.PHONY: clean
+clean:
+	if [ -f ${LIB_NAME} ] ; then rm ${LIB_NAME} ; fi
+	if [ -f test ] ; then rm test ; fi

--- a/client/cgo/cgotest.go
+++ b/client/cgo/cgotest.go
@@ -1,0 +1,245 @@
+package main
+
+/*
+int testVerifyVrf(unsigned char *pk, int pkSize,
+    unsigned char *m, int mSize,
+    unsigned char *index, int indexSize,
+    unsigned char *proof, int proofSize) {
+    return cgoVerifyVrf(pk, pkSize, m, mSize, index, indexSize, proof, proofSize);
+}
+
+int testVerifySignature(
+    unsigned char *pk, int pkSize,
+    unsigned char *m, int mSize,
+    unsigned char *sig, int sigSize) {
+    return cgoVerifySignature(pk, pkSize, m, mSize, sig, sigSize);
+}
+
+int testVerifyHashChain(
+	unsigned char *prevHash, int hashSize,
+    unsigned char *strSig, int sigSize) {
+    return cgoVerifyHashChain(prevHash, hashSize, strSig, sigSize);
+}
+
+int testVerifyAuthPath(
+    unsigned char *treeHash, int treeHashSize,
+    unsigned char *treeNonce, int treeNonceSize,
+    unsigned char *lookupIndex, int lookupIndexSize,
+    unsigned char **prunedTree, int prunedTreeSize, int hashSize,
+    int leafLevel,
+    unsigned char *leafIndex, int leafIndexSize,
+    unsigned char *leafCommitment, int leafCommitmentSize,
+    int isLeafEmpty) {
+    return cgoVerifyAuthPath(treeHash, treeHashSize,
+        treeNonce, treeNonceSize,
+        lookupIndex, lookupIndexSize,
+        prunedTree, prunedTreeSize, hashSize,
+        leafLevel,
+        leafIndex, leafIndexSize,
+        leafCommitment, leafCommitmentSize,
+        isLeafEmpty);
+}
+
+#cgo CFLAGS: -Wno-implicit-function-declaration
+*/
+import "C"
+import (
+	"bytes"
+	"testing"
+	"unsafe"
+
+	"github.com/coniks-sys/coniks-go/crypto/sign"
+	"github.com/coniks-sys/coniks-go/crypto/vrf"
+	"github.com/coniks-sys/coniks-go/merkletree"
+)
+
+func byteSliceToCpchar(buf []byte) *C.uchar {
+	ptr := unsafe.Pointer(&buf[0])
+	return (*C.uchar)(ptr)
+}
+
+func testVerifyVrf(t *testing.T) {
+	pk, sk, err := vrf.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	alice := []byte("alice")
+	aliceVRF, aliceProof := sk.Prove(alice)
+	if v := C.testVerifyVrf(byteSliceToCpchar(pk[:]), C.int(len(pk)),
+		byteSliceToCpchar(alice), C.int(len(alice)),
+		byteSliceToCpchar(aliceVRF), C.int(len(aliceVRF)),
+		byteSliceToCpchar(aliceProof), C.int(len(aliceProof))); v != 1 {
+		t.Error("cgoVrfVerify failed")
+	}
+}
+
+func testVerifySignature(t *testing.T) {
+	key, err := sign.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	message := []byte("test message")
+	sig := key.Sign(message)
+
+	pk, ok := key.Public()
+	if !ok {
+		t.Errorf("bad PK?")
+	}
+
+	if v := C.testVerifySignature(byteSliceToCpchar(pk), C.int(len(pk)),
+		byteSliceToCpchar(message), C.int(len(message)),
+		byteSliceToCpchar(sig), C.int(len(sig))); v != 1 {
+		t.Error("cgoVerifySignature failed")
+	}
+}
+
+func testVerifyHashChain(t *testing.T) {
+	signKey, err := sign.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, vrfPrivKey, err := vrf.GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pad, err := merkletree.NewPAD(merkletree.NewPolicies(2, vrfPrivKey), signKey, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+	key1 := "key1"
+	val1 := []byte("value1")
+
+	if err := pad.Set(key1, val1); err != nil {
+		t.Fatal(err)
+	}
+	pad.Update(nil)
+	str0 := pad.GetSTR(0)
+	str1 := pad.GetSTR(1)
+
+	if v := C.testVerifyHashChain(byteSliceToCpchar(str1.PreviousSTRHash), C.int(len(str1.PreviousSTRHash)),
+		byteSliceToCpchar(str0.Signature), C.int(len(str0.Signature))); v != 1 {
+		t.Error("cgoVerifyHashChain failed")
+	}
+}
+
+func testVerifyAuthPath(t *testing.T) {
+	signKey, err := sign.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, vrfPrivKey, err := vrf.GenerateKey(bytes.NewReader(
+		[]byte("deterministic tests need 256 bit")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pad, err := merkletree.NewPAD(merkletree.NewPolicies(2, vrfPrivKey), signKey, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key1 := "key1"
+	val1 := []byte("value1")
+	key2 := "key2"
+	val2 := []byte("value2")
+	key3 := "key3"
+	val3 := []byte("value3")
+
+	if err := pad.Set(key1, val1); err != nil {
+		t.Fatal(err)
+	}
+	if err := pad.Set(key2, val2); err != nil {
+		t.Fatal(err)
+	}
+	if err := pad.Set(key3, val3); err != nil {
+		t.Fatal(err)
+	}
+	pad.Update(nil)
+
+	// proof of inclusion
+	proof, err := pad.Lookup(key3)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	isLeafEmpty := 0
+	if proof.Leaf.IsEmpty() {
+		isLeafEmpty = 1
+	}
+	if v := C.testVerifyAuthPath(byteSliceToCpchar(pad.GetLatestSTR().Root()), C.int(len(pad.GetLatestSTR().Root())),
+		byteSliceToCpchar(proof.TreeNonce), C.int(len(proof.TreeNonce)),
+		byteSliceToCpchar(proof.LookupIndex), C.int(len(proof.LookupIndex)),
+		(**C.uchar)(unsafe.Pointer(&proof.PrunedTree[0][0])), C.int(len(proof.PrunedTree)), C.int(len(proof.PrunedTree[0])),
+		C.int(proof.Leaf.Level()),
+		byteSliceToCpchar(proof.Leaf.Index()), C.int(len(proof.Leaf.Index())),
+		byteSliceToCpchar(proof.Leaf.Commitment()), C.int(len(proof.Leaf.Commitment())),
+		C.int(isLeafEmpty)); v != 1 {
+		t.Error("Verify proof of inclusion failed")
+	}
+
+	// proof of absence
+	proof, err = pad.Lookup("123")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	isLeafEmpty = 0
+	if proof.Leaf.IsEmpty() {
+		isLeafEmpty = 1
+	}
+	if v := C.testVerifyAuthPath(byteSliceToCpchar(pad.GetLatestSTR().Root()), C.int(len(pad.GetLatestSTR().Root())),
+		byteSliceToCpchar(proof.TreeNonce), C.int(len(proof.TreeNonce)),
+		byteSliceToCpchar(proof.LookupIndex), C.int(len(proof.LookupIndex)),
+		(**C.uchar)(unsafe.Pointer(&proof.PrunedTree[0][0])), C.int(len(proof.PrunedTree)), C.int(len(proof.PrunedTree[0])),
+		C.int(proof.Leaf.Level()),
+		byteSliceToCpchar(proof.Leaf.Index()), C.int(len(proof.Leaf.Index())),
+		nil, C.int(0),
+		C.int(isLeafEmpty)); v != 1 {
+		t.Error("Verify proof of absence failed")
+	}
+}
+
+func testVerifyProofOfAbsenceSamePrefix(t *testing.T) {
+	signKey, err := sign.GenerateKey()
+	if err != nil {
+		t.Fatal(err)
+	}
+	_, vrfPrivKey, err := vrf.GenerateKey(bytes.NewReader(
+		[]byte("deterministic tests need 256 bit")))
+	if err != nil {
+		t.Fatal(err)
+	}
+	pad, err := merkletree.NewPAD(merkletree.NewPolicies(2, vrfPrivKey), signKey, 10)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	key1 := "key1"
+	val1 := []byte("value1")
+
+	if err := pad.Set(key1, val1); err != nil {
+		t.Fatal(err)
+	}
+	pad.Update(nil)
+
+	// proof of inclusion
+	proof, err := pad.Lookup("a")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	isLeafEmpty := 0
+	if proof.Leaf.IsEmpty() {
+		isLeafEmpty = 1
+	}
+	if v := C.testVerifyAuthPath(byteSliceToCpchar(pad.GetLatestSTR().Root()), C.int(len(pad.GetLatestSTR().Root())),
+		byteSliceToCpchar(proof.TreeNonce), C.int(len(proof.TreeNonce)),
+		byteSliceToCpchar(proof.LookupIndex), C.int(len(proof.LookupIndex)),
+		(**C.uchar)(unsafe.Pointer(&proof.PrunedTree[0][0])), C.int(len(proof.PrunedTree)), C.int(len(proof.PrunedTree[0])),
+		C.int(proof.Leaf.Level()),
+		byteSliceToCpchar(proof.Leaf.Index()), C.int(len(proof.Leaf.Index())),
+		byteSliceToCpchar(proof.Leaf.Commitment()), C.int(len(proof.Leaf.Commitment())),
+		C.int(isLeafEmpty)); v != 1 {
+		t.Error("Verify proof of absence failed")
+	}
+}

--- a/client/cgo/verification.go
+++ b/client/cgo/verification.go
@@ -1,0 +1,122 @@
+package main
+
+import "C"
+
+import (
+	"bytes"
+	"unsafe"
+
+	"github.com/coniks-sys/coniks-go/crypto"
+	"github.com/coniks-sys/coniks-go/crypto/sign"
+	"github.com/coniks-sys/coniks-go/crypto/vrf"
+	"github.com/coniks-sys/coniks-go/merkletree"
+)
+
+// main is required to build a shared library, but does nothing
+func main() {}
+
+//export cgoVerifySignature
+func cgoVerifySignature(pk unsafe.Pointer, pkSize C.int,
+	message unsafe.Pointer, size C.int,
+	sig unsafe.Pointer, sigSize C.int) C.int {
+	if int(pkSize) != sign.PublicKeySize ||
+		int(sigSize) != sign.SignatureSize {
+		return 0
+	}
+	pkBytes := C.GoBytes(pk, pkSize)
+	messageBytes := C.GoBytes(message, size)
+	sigBytes := C.GoBytes(sig, sigSize)
+	key := sign.PublicKey(pkBytes)
+	if key.Verify(messageBytes, sigBytes) {
+		return 1
+	}
+	return 0
+}
+
+//export cgoVerifyVrf
+func cgoVerifyVrf(pk unsafe.Pointer, pkSize C.int,
+	m unsafe.Pointer, size C.int,
+	index unsafe.Pointer, indexSize C.int,
+	proof unsafe.Pointer, proofSize C.int) C.int {
+	if int(pkSize) != vrf.PublicKeySize ||
+		int(indexSize) != vrf.Size ||
+		int(proofSize) != vrf.ProofSize {
+		return 0
+	}
+	pkBytes := C.GoBytes(pk, pkSize)
+	mBytes := C.GoBytes(m, size)
+	vrfBytes := C.GoBytes(index, indexSize)
+	proofBytes := C.GoBytes(proof, proofSize)
+	var key vrf.PublicKey
+	copy(key[:], pkBytes)
+	if key.Verify(mBytes, vrfBytes, proofBytes) {
+		return 1
+	}
+	return 0
+}
+
+//export cgoVerifyHashChain
+func cgoVerifyHashChain(prevHash unsafe.Pointer, hashSize C.int,
+	savedStrSig unsafe.Pointer, sigSize C.int) C.int {
+	if int(hashSize) != crypto.HashSizeByte ||
+		int(sigSize) != sign.SignatureSize {
+		return 0
+	}
+	prevHashBytes := C.GoBytes(prevHash, hashSize)
+	sigBytes := C.GoBytes(savedStrSig, sigSize)
+	strHash := crypto.Digest(sigBytes)
+	if bytes.Equal(prevHashBytes, strHash) {
+		return 1
+	}
+	return 0
+}
+
+//export cgoVerifyAuthPath
+//must call cgoVerifyVrf first to verify the returned vrf index.
+func cgoVerifyAuthPath(treeHash unsafe.Pointer, treeHashSize C.int,
+	treeNonce unsafe.Pointer, treeNonceSize C.int,
+	lookupIndex unsafe.Pointer, indexSize C.int,
+	prunedHashes unsafe.Pointer, prunedSize C.int, hashSize C.int,
+	leafLevel C.int,
+	leafIndex unsafe.Pointer, leafIndexSize C.int,
+	leafCommitment unsafe.Pointer, commitmentSize C.int,
+	isLeafEmpty C.int) C.int {
+
+	if int(treeHashSize) != crypto.HashSizeByte ||
+		int(treeNonceSize) != crypto.HashSizeByte ||
+		int(indexSize) != vrf.Size ||
+		int(hashSize) != crypto.HashSizeByte ||
+		int(prunedSize) < 1 {
+		return 0
+	}
+	if int(isLeafEmpty) != 1 && // user leaf node
+		(int(leafIndexSize) != vrf.Size ||
+			int(commitmentSize) != crypto.HashSizeByte) {
+		return 0
+	}
+
+	th := C.GoBytes(treeHash, treeHashSize)
+	tn := C.GoBytes(treeNonce, treeNonceSize)
+	li := C.GoBytes(lookupIndex, indexSize)
+	leafi := C.GoBytes(leafIndex, leafIndexSize)
+	leafc := C.GoBytes(leafCommitment, commitmentSize)
+
+	buf := C.GoBytes(prunedHashes, prunedSize*hashSize)
+	pt := make([][crypto.HashSizeByte]byte, 0, prunedSize)
+	for i := 0; i < int(prunedSize); i++ {
+		var arr [crypto.HashSizeByte]byte
+		copy(arr[:], buf[:hashSize])
+		pt = append(pt, arr)
+		buf = buf[hashSize:]
+	}
+
+	ap := new(merkletree.AuthenticationPath)
+	ap.TreeNonce = tn
+	ap.LookupIndex = li
+	ap.PrunedTree = pt
+
+	if merkletree.VerifyAuthPath(ap, leafi, leafc, int(leafLevel), int(isLeafEmpty) == 1, th) {
+		return 1
+	}
+	return 0
+}

--- a/client/cgo/verification_test.go
+++ b/client/cgo/verification_test.go
@@ -1,0 +1,13 @@
+package main
+
+import "testing"
+
+func TestVerifyVrf(t *testing.T) { testVerifyVrf(t) }
+
+func TestVerifySignature(t *testing.T) { testVerifySignature(t) }
+
+func TestVerifyHashChain(t *testing.T) { testVerifyHashChain(t) }
+
+func TestVerifyAuthPath(t *testing.T) { testVerifyAuthPath(t) }
+
+func TestVerifyProofOfAbsenceSamePrefix(t *testing.T) { testVerifyProofOfAbsenceSamePrefix(t) }

--- a/crypto/sign/sign.go
+++ b/crypto/sign/sign.go
@@ -9,6 +9,7 @@ import (
 const (
 	PrivateKeySize = 64
 	PublicKeySize  = 32
+	SignatureSize  = 64
 )
 
 type PrivateKey ed25519.PrivateKey

--- a/crypto/sign/sign_test.go
+++ b/crypto/sign/sign_test.go
@@ -1,6 +1,9 @@
 package sign
 
 import (
+	"bytes"
+	"crypto/rand"
+	"errors"
 	"testing"
 )
 
@@ -27,4 +30,39 @@ func TestVerifySignature(t *testing.T) {
 	if pk.Verify(wrongMessage, sig) {
 		t.Errorf("signature of different message accepted")
 	}
+}
+
+func TestDigest(t *testing.T) {
+	msg := []byte("test message")
+	d := Digest(msg)
+	if len(d) != HashSizeByte {
+		t.Fatal("Computation of Hash failed.")
+	}
+	if bytes.Equal(d, make([]byte, HashSizeByte)) {
+		t.Fatal("Hash is all zeros.")
+	}
+}
+
+type testErrorRandReader struct{}
+
+func (er testErrorRandReader) Read([]byte) (int, error) {
+	return 0, errors.New("Not enough entropy!")
+}
+
+func TestMakeRand(t *testing.T) {
+	r, err := MakeRand()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// check if hashed the random output:
+	if len(r) != HashSizeByte {
+		t.Fatal("Looks like Digest wasn't called correctly.")
+	}
+	orig := rand.Reader
+	rand.Reader = testErrorRandReader{}
+	r, err = MakeRand()
+	if err == nil {
+		t.Fatal("No error returned")
+	}
+	rand.Reader = orig
 }

--- a/crypto/sign/sign_test.go
+++ b/crypto/sign/sign_test.go
@@ -1,9 +1,6 @@
 package sign
 
 import (
-	"bytes"
-	"crypto/rand"
-	"errors"
 	"testing"
 )
 
@@ -30,39 +27,4 @@ func TestVerifySignature(t *testing.T) {
 	if pk.Verify(wrongMessage, sig) {
 		t.Errorf("signature of different message accepted")
 	}
-}
-
-func TestDigest(t *testing.T) {
-	msg := []byte("test message")
-	d := Digest(msg)
-	if len(d) != HashSizeByte {
-		t.Fatal("Computation of Hash failed.")
-	}
-	if bytes.Equal(d, make([]byte, HashSizeByte)) {
-		t.Fatal("Hash is all zeros.")
-	}
-}
-
-type testErrorRandReader struct{}
-
-func (er testErrorRandReader) Read([]byte) (int, error) {
-	return 0, errors.New("Not enough entropy!")
-}
-
-func TestMakeRand(t *testing.T) {
-	r, err := MakeRand()
-	if err != nil {
-		t.Fatal(err)
-	}
-	// check if hashed the random output:
-	if len(r) != HashSizeByte {
-		t.Fatal("Looks like Digest wasn't called correctly.")
-	}
-	orig := rand.Reader
-	rand.Reader = testErrorRandReader{}
-	r, err = MakeRand()
-	if err == nil {
-		t.Fatal("No error returned")
-	}
-	rand.Reader = orig
 }

--- a/crypto/util_test.go
+++ b/crypto/util_test.go
@@ -1,0 +1,43 @@
+package crypto
+
+import (
+	"bytes"
+	"crypto/rand"
+	"errors"
+	"testing"
+)
+
+func TestDigest(t *testing.T) {
+	msg := []byte("test message")
+	d := Digest(msg)
+	if len(d) != HashSizeByte {
+		t.Fatal("Computation of Hash failed.")
+	}
+	if bytes.Equal(d, make([]byte, HashSizeByte)) {
+		t.Fatal("Hash is all zeros.")
+	}
+}
+
+type testErrorRandReader struct{}
+
+func (er testErrorRandReader) Read([]byte) (int, error) {
+	return 0, errors.New("Not enough entropy!")
+}
+
+func TestMakeRand(t *testing.T) {
+	r, err := MakeRand()
+	if err != nil {
+		t.Fatal(err)
+	}
+	// check if hashed the random output:
+	if len(r) != HashSizeByte {
+		t.Fatal("Looks like Digest wasn't called correctly.")
+	}
+	orig := rand.Reader
+	rand.Reader = testErrorRandReader{}
+	r, err = MakeRand()
+	if err == nil {
+		t.Fatal("No error returned")
+	}
+	rand.Reader = orig
+}

--- a/merkletree/pad_test.go
+++ b/merkletree/pad_test.go
@@ -253,15 +253,11 @@ func TestTB(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// TODO shouldn't there be a serialize function?
-	tbb := pad.latestSTR.Signature
-	tbb = append(tbb, tb.Index...)
-	tbb = append(tbb, tb.Value...)
-
 	pk, ok := pad.signKey.Public()
 	if !ok {
 		t.Fatal("Couldn't retrieve public-key.")
 	}
+	tbb := tb.Serialize(pad.latestSTR.Signature)
 	if !pk.Verify(tbb, tb.Signature) {
 		t.Fatal("Couldn't validate signature")
 	}

--- a/merkletree/pad_test.go
+++ b/merkletree/pad_test.go
@@ -285,8 +285,7 @@ func TestNewPADMissingPolicies(t *testing.T) {
 	}
 }
 
-// TODO move this to helper "mockRandReader" or sth like that; and provide a
-// an equivalent function to reset the original rand.Reader
+// TODO move the following to some (internal?) testutils package
 type testErrorRandReader struct{}
 
 func (er testErrorRandReader) Read([]byte) (int, error) {
@@ -319,14 +318,14 @@ func BenchmarkCreateLargePAD(b *testing.B) {
 	valuePrefix := []byte("value")
 
 	// total number of entries in tree:
-	NumEntries := 1000000
+	NumEntries := uint64(1000000)
 	// tree.Clone and update STR every:
 	noUpdate := uint64(NumEntries + 1)
 
 	b.ResetTimer()
 	// benchmark creating a large tree (don't Update tree)
-	for n := 0; n < b.N && n < NumEntries; n++ {
-		_, err := createPad(uint64(NumEntries), keyPrefix, valuePrefix, snapLen,
+	for n := 0; n < b.N; n++ {
+		_, err := createPad(NumEntries, keyPrefix, valuePrefix, snapLen,
 			noUpdate)
 		if err != nil {
 			b.Fatal(err)

--- a/merkletree/proof_test.go
+++ b/merkletree/proof_test.go
@@ -112,3 +112,11 @@ func TestVerifyProofSamePrefix(t *testing.T) {
 		t.Error("Proof of absence verification failed.")
 	}
 }
+
+func TestEmptyNodeCommitment(t *testing.T) {
+	n := node{parent: nil, level: 1}
+	e := emptyNode{node: n, index: []byte("some index")}
+	if c := e.Commitment(); c != nil {
+		t.Fatal("Commitment of emptyNode should be nil")
+	}
+}

--- a/merkletree/str.go
+++ b/merkletree/str.go
@@ -7,10 +7,6 @@ import (
 	"github.com/coniks-sys/coniks-go/utils"
 )
 
-var (
-	ErrorBadEpoch = errors.New("[merkletree] Bad STR Epoch. STR's epoch must be nonzero")
-)
-
 // SignedTreeRoot represents a signed tree root, which is generated
 // at the beginning of every epoch.
 // Signed tree roots contain the current root node,

--- a/merkletree/str.go
+++ b/merkletree/str.go
@@ -1,8 +1,6 @@
 package merkletree
 
 import (
-	"errors"
-
 	"github.com/coniks-sys/coniks-go/crypto/sign"
 	"github.com/coniks-sys/coniks-go/utils"
 )
@@ -23,9 +21,6 @@ type SignedTreeRoot struct {
 }
 
 func NewSTR(key sign.PrivateKey, policies Policies, m *MerkleTree, epoch uint64, prevHash []byte) *SignedTreeRoot {
-	if epoch < 0 {
-		panic(ErrorBadEpoch)
-	}
 	prevEpoch := epoch - 1
 	if epoch == 0 {
 		prevEpoch = 0

--- a/utils/util_test.go
+++ b/utils/util_test.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"encoding/binary"
 	"math/rand"
 	"testing"
 	"time"
@@ -26,4 +27,36 @@ func TestBitsBytesConvert(t *testing.T) {
 			t.Error("Wrong conversion")
 		}
 	}
+}
+
+func TestIntToBytes(t *testing.T) {
+	numInt := 42
+	b := IntToBytes(numInt)
+	if int(binary.LittleEndian.Uint32(b)) != numInt {
+		t.Fatal("Conversion to bytes looks wrong!")
+	}
+	// TODO It is possible to call `IntToBytes` with a signed int < 0
+	// isn't that problematic?
+	// for instance this will fail:
+	// b := IntToBytes(-42)
+	// if int(binary.LittleEndian.Uint32(b)) != numInt {
+	// 	t.Fatal("Conversion to bytes looks wrong!")
+	// }
+}
+
+func TestULongToBytes(t *testing.T) {
+	numInt := uint64(42)
+	b := ULongToBytes(numInt)
+	if binary.LittleEndian.Uint64(b) != numInt {
+		t.Fatal("Conversion to bytes looks wrong!")
+	}
+}
+
+func TestLongToBytes(t *testing.T) {
+	numInt := int64(42)
+	b := LongToBytes(numInt)
+	if int64(binary.LittleEndian.Uint64(b)) != numInt {
+		t.Fatal("Conversion to bytes looks wrong!")
+	}
+	// TODO similar problem as in TestIntToBytes
 }


### PR DESCRIPTION
I merged branch `no-getset` since we can take the advantages of struct fields (e.g., https://github.com/coniks-sys/coniks-go/blob/9c253690f74c41d9763111bd660cbb8108236b86/client/cgo/coniks.go#L105-L107). 
I will fixed other getters when the #36 is clarified.