### PR TITLE
Add kv db interface

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,10 +1,11 @@
 This license applies to all parts of the CONIKS Golang library and reference implementation except the following:
-- Coname utility functions, located in utils/coname.go
-This module is copyrighted by the Coname Authors.
 - The ed25519 subpackage, located in crypto/ed25519
 This subpackage is copyrighted by the Go Authors.
+- Coname utility functions, located in utils/coname.go
 - The vrf subpackage, located in crypto/vrf
-This subpackage is copyrighted by the Coname Authors.
+- The kv subpackage, located in storage/kv
+- The leveldbkv subpackage, located in storage/kv/leveldbkv
+These subpackages are copyrighted by the Coname Authors.
 
 Copyright (c) 2016, Princeton University.
 Copyright (c) 2016, Ecole Polytechnique Federale de Lausanne (EPFL).

--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ The packages in this library implement the various components of the CONIKS syst
 - ``crypto``: Cryptographic algorithms and operations
 - ``merkletree``: Merkle prefix tree and related data structures
 - ``utils``: Utility functions 
+- ``storage``: DB hooks for storage backend (currently the library supports key-value db only)
 
 ## Disclaimer
 Please keep in mind that this CONIKS library is under active development. The repository may contain experimental features that aren't fully tested. We recommend using a [tagged release](https://github.com/coniks-sys/coniks-go/releases).

--- a/storage/kv/kv.go
+++ b/storage/kv/kv.go
@@ -1,0 +1,64 @@
+// Copyright 2014-2015 The Coname Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+// Package kv contains a generic interface for key-value databases with support
+// for batch writes. All operations are safe for concurrent use, atomic and
+// synchronously persistent.
+package kv
+
+import "errors"
+
+// DB is an abstract ordered key-value store. All operations are assumed to be
+// synchronous, atomic and linearizable. This includes the following guarantee:
+// After Put(k, v) has returned, and as long as no other Put(k, ?) has been
+// called happened, Get(k) MUST return always v, regardless of whether the
+// process or the entire system has been reset in the meantime or very little
+// time has passed. To amortize the overhead of synchronous writes, DB offers
+// batch operations: Write(...) performs a series of Put-s atomically (and
+// possibly almost as fast as a single Put).
+type DB interface {
+	Get(key []byte) ([]byte, error)
+	Put(key, value []byte) error
+	Delete(key []byte) error
+	NewBatch() Batch
+	Write(Batch) error
+	NewIterator(*Range) Iterator
+	Close() error
+
+	ErrNotFound() error
+}
+
+// A Batch contains a sequence of Put-s waiting to be Write-n to a DB.
+type Batch interface {
+	Reset()
+	Put(key, value []byte)
+	Delete(key []byte)
+}
+
+// Iterator is an abstract pointer to a DB entry. It must be valid to call
+// Error() after release. The boolean return values indicate whether the
+// requested entry exists.
+type Iterator interface {
+	Key() []byte
+	Value() []byte
+	First() bool
+	Next() bool
+	Last() bool
+	Release()
+	Error() error
+}
+
+var (
+	ErrorBadBufferLength = errors.New("[kv] Bad KV buffer's length")
+)

--- a/storage/kv/leveldbkv/leveldbkv.go
+++ b/storage/kv/leveldbkv/leveldbkv.go
@@ -1,0 +1,80 @@
+// Copyright 2014-2015 The Coname Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+// Package leveldbkv implements the kv interface using leveldb
+package leveldbkv
+
+import (
+	"fmt"
+
+	"github.com/coniks-sys/coniks-go/storage/kv"
+	"github.com/syndtr/goleveldb/leveldb"
+	"github.com/syndtr/goleveldb/leveldb/opt"
+	"github.com/syndtr/goleveldb/leveldb/util"
+)
+
+type leveldbkv leveldb.DB
+
+func OpenDB(path string) kv.DB {
+	// open db & keep it open
+	db, err := leveldb.OpenFile(path, nil)
+	if err != nil {
+		panic(err)
+	}
+	return Wrap(db)
+}
+
+// Wrap uses a leveldb.DB as a kv.DB the obvious way (and with Sync:true).
+func Wrap(db *leveldb.DB) kv.DB {
+	return (*leveldbkv)(db)
+}
+
+func (db *leveldbkv) Get(key []byte) ([]byte, error) {
+	return (*leveldb.DB)(db).Get(key, nil)
+}
+
+func (db *leveldbkv) Put(key, value []byte) error {
+	return (*leveldb.DB)(db).Put(key, value, &opt.WriteOptions{Sync: true})
+}
+
+func (db *leveldbkv) Delete(key []byte) error {
+	return (*leveldb.DB)(db).Delete(key, &opt.WriteOptions{Sync: true})
+}
+
+func (db *leveldbkv) NewBatch() kv.Batch {
+	return new(leveldb.Batch)
+}
+
+func (db *leveldbkv) Write(b kv.Batch) error {
+	wb, ok := b.(*leveldb.Batch)
+	if !ok {
+		return fmt.Errorf("leveldbkv.Write: expected *leveldb.Batch, got %T", b)
+	}
+	return (*leveldb.DB)(db).Write(wb, &opt.WriteOptions{Sync: true})
+}
+
+func (db *leveldbkv) NewIterator(rg *kv.Range) kv.Iterator {
+	if rg == nil {
+		return (*leveldb.DB)(db).NewIterator(nil, nil)
+	}
+	return (*leveldb.DB)(db).NewIterator(&util.Range{Start: rg.Start, Limit: rg.Limit}, nil)
+}
+
+func (db *leveldbkv) Close() error {
+	return (*leveldb.DB)(db).Close()
+}
+
+func (db *leveldbkv) ErrNotFound() error {
+	return leveldb.ErrNotFound
+}

--- a/storage/kv/range.go
+++ b/storage/kv/range.go
@@ -1,0 +1,72 @@
+// Copyright 2014-2015 The Coname Authors.
+//
+// Licensed under the Apache License, Version 2.0 (the "License"); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+// 	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+// Copyright 2012 Suryandaru Triandana <syndtr@gmail.com>
+// Modified in 2015 by Andres Erbsen <andreser@yahoo-inc.com>
+// All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//     * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//     * Redistributions in binary form must reproduce the above copyright
+// notice, this list of conditions and the following disclaimer in the
+// documentation and/or other materials provided with the distribution.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+package kv
+
+// Range is a key range.
+type Range struct {
+	// Start of the key range, included in the range.
+	Start []byte
+
+	// Limit of the key range, not included in the range. nil indicates no limit.
+	Limit []byte
+}
+
+// IncrementKey returns the lexicographically first DB key which is greater
+// than all keys prefixed by "prefix". Following the Range.Limit convention,
+// IncrementKey may return nil, a sentinel value that is to be interpreted as
+// greater than all keys.
+func IncrementKey(prefix []byte) []byte {
+	for i := len(prefix) - 1; i >= 0; i-- {
+		c := prefix[i]
+		if c < 0xff {
+			limit := make([]byte, i+1)
+			copy(limit, prefix)
+			limit[i] = c + 1
+			return limit
+		}
+	}
+	return nil
+}
+
+// BytesPrefix returns key range that satisfy the given prefix.
+func BytesPrefix(prefix []byte) *Range {
+	return &Range{prefix, IncrementKey(prefix)}
+}


### PR DESCRIPTION
Since the storage interface would be used both in the `server-registration` and `db` branch, I would like to make a separate PR for this interface implementation. 

Compare to the original version from `coname` repo, I added the `Close` method into the interface. 