### PR TITLE
Refactoring: use unsigned int32 instead of int where it makes sense

### DIFF
--- a/client/cgo/verification.go
+++ b/client/cgo/verification.go
@@ -113,7 +113,7 @@ func cgoVerifyAuthPath(treeHash unsafe.Pointer, treeHashSize C.int,
 	ap.LookupIndex = li
 	ap.PrunedTree = pt
 
-	if merkletree.VerifyAuthPath(ap, leafi, leafc, int(leafLevel), int(isLeafEmpty) == 1, th) {
+	if merkletree.VerifyAuthPath(ap, leafi, leafc, uint32(leafLevel), int(isLeafEmpty) == 1, th) {
 		return 1
 	}
 	return 0

--- a/merkletree/merkletree.go
+++ b/merkletree/merkletree.go
@@ -112,7 +112,7 @@ func (m *MerkleTree) Set(index []byte, key string, value []byte) error {
 
 func (m *MerkleTree) insertNode(index []byte, toAdd *userLeafNode) {
 	indexBits := util.ToBits(index)
-	depth := 0
+	var depth uint32 // = 0
 	var nodePointer MerkleNode
 	nodePointer = m.root
 

--- a/merkletree/merkletree_test.go
+++ b/merkletree/merkletree_test.go
@@ -37,7 +37,7 @@ func TestOneEntry(t *testing.T) {
 	h.Write([]byte{EmptyBranchIdentifier})
 	h.Write(m.nonce)
 	h.Write(util.ToBytes([]bool{true}))
-	h.Write(util.IntToBytes(1))
+	h.Write(util.UInt32ToBytes(1))
 	h.Read(expect[:])
 	if !bytes.Equal(m.root.rightHash, expect[:]) {
 		t.Error("Wrong righ hash!",
@@ -66,7 +66,7 @@ func TestOneEntry(t *testing.T) {
 	h.Write([]byte{LeafIdentifier})
 	h.Write(m.nonce)
 	h.Write(index)
-	h.Write(util.IntToBytes(1))
+	h.Write(util.UInt32ToBytes(1))
 	h.Write(commit[:])
 	h.Read(expect[:])
 

--- a/merkletree/node.go
+++ b/merkletree/node.go
@@ -7,7 +7,7 @@ import (
 
 type node struct {
 	parent MerkleNode
-	level  int
+	level  uint32
 }
 
 type interiorNode struct {
@@ -32,7 +32,7 @@ type emptyNode struct {
 	index []byte
 }
 
-func NewInteriorNode(parent MerkleNode, level int, prefixBits []bool) *interiorNode {
+func NewInteriorNode(parent MerkleNode, level uint32, prefixBits []bool) *interiorNode {
 	prefixLeft := append([]bool(nil), prefixBits...)
 	prefixLeft = append(prefixLeft, false)
 	prefixRight := append([]bool(nil), prefixBits...)
@@ -88,20 +88,20 @@ func (n *interiorNode) Hash(m *MerkleTree) []byte {
 
 func (n *userLeafNode) Hash(m *MerkleTree) []byte {
 	return crypto.Digest(
-		[]byte{LeafIdentifier},           // K_leaf
-		[]byte(m.nonce),                  // K_n
-		[]byte(n.index),                  // i
-		[]byte(util.IntToBytes(n.level)), // l
-		[]byte(n.commitment),             // commit(key|| value)
+		[]byte{LeafIdentifier},              // K_leaf
+		[]byte(m.nonce),                     // K_n
+		[]byte(n.index),                     // i
+		[]byte(util.UInt32ToBytes(n.level)), // l
+		[]byte(n.commitment),                // commit(key|| value)
 	)
 }
 
 func (n *emptyNode) Hash(m *MerkleTree) []byte {
 	return crypto.Digest(
-		[]byte{EmptyBranchIdentifier},    // K_empty
-		[]byte(m.nonce),                  // K_n
-		[]byte(n.index),                  // i
-		[]byte(util.IntToBytes(n.level)), // l
+		[]byte{EmptyBranchIdentifier},       // K_empty
+		[]byte(m.nonce),                     // K_n
+		[]byte(n.index),                     // i
+		[]byte(util.UInt32ToBytes(n.level)), // l
 	)
 }
 

--- a/utils/util.go
+++ b/utils/util.go
@@ -6,7 +6,7 @@ import "encoding/binary"
 // at offset offset, and determines whether it is 1 or 0.
 // return true if the nth bit is 1, false otherwise.
 // from MSB to LSB order
-func GetNthBit(bs []byte, offset int) bool {
+func GetNthBit(bs []byte, offset uint32) bool {
 	arrayOffset := offset / 8
 	bitOfByte := offset % 8
 
@@ -15,7 +15,7 @@ func GetNthBit(bs []byte, offset int) bool {
 }
 
 // LongToBytes converts an int64 variable to byte array
-// in litte endian format
+// in little endian format
 func LongToBytes(num int64) []byte {
 	buf := make([]byte, 8)
 	binary.LittleEndian.PutUint64(buf, uint64(num))
@@ -23,15 +23,15 @@ func LongToBytes(num int64) []byte {
 }
 
 // ULongToBytes converts an uint64 variable to byte array
-// in litte endian format
+// in little endian format
 func ULongToBytes(num uint64) []byte {
 	return LongToBytes(int64(num))
 }
 
-// IntToBytes converts an int variable to byte array
-// in litte endian format
-func IntToBytes(num int) []byte {
+// UInt32ToBytes converts an uint32 variable to byte array
+// in little endian format
+func UInt32ToBytes(num uint32) []byte {
 	buf := make([]byte, 4)
-	binary.LittleEndian.PutUint32(buf, uint32(num))
+	binary.LittleEndian.PutUint32(buf, num)
 	return buf
 }

--- a/utils/util_test.go
+++ b/utils/util_test.go
@@ -22,22 +22,17 @@ func TestBitsBytesConvert(t *testing.T) {
 
 	bytes := ToBytes(bits)
 
-	for i := 0; i < 16; i++ {
+	for i := uint32(0); i < 16; i++ {
 		if GetNthBit(bytes, i) != bits[i] {
 			t.Error("Wrong conversion")
 		}
 	}
 }
 
-func TestIntToBytes(t *testing.T) {
-	numInt := 42
-	b := IntToBytes(numInt)
-	if int(binary.LittleEndian.Uint32(b)) != numInt {
-		t.Fatal("Conversion to bytes looks wrong!")
-	}
-	numInt = -42
-	b = IntToBytes(numInt)
-	if int32(binary.LittleEndian.Uint32(b)) != int32(numInt) {
+func TestUInt32ToBytes(t *testing.T) {
+	numInt := uint32(42)
+	b := UInt32ToBytes(numInt)
+	if binary.LittleEndian.Uint32(b) != numInt {
 		t.Fatal("Conversion to bytes looks wrong!")
 	}
 }


### PR DESCRIPTION
Small refactoring. Should resolve #53.
I chose `uint32` as the type for leaf nodes' level as its max value should be more then large enough and its size in memory is the same as `int`'s.