### PR TITLE
Remove unnecessary Policies's method & add new util functions

### DIFF
--- a/client/cgo/cgotest.go
+++ b/client/cgo/cgotest.go
@@ -90,7 +90,7 @@ func testVerifyVrf(t *testing.T) {
 }
 
 func testVerifySignature(t *testing.T) {
-	key, err := sign.GenerateKey()
+	key, err := sign.GenerateKey(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -111,7 +111,7 @@ func testVerifySignature(t *testing.T) {
 }
 
 func testVerifyHashChain(t *testing.T) {
-	signKey, err := sign.GenerateKey()
+	signKey, err := sign.GenerateKey(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -140,7 +140,7 @@ func testVerifyHashChain(t *testing.T) {
 }
 
 func testVerifyAuthPath(t *testing.T) {
-	signKey, err := sign.GenerateKey()
+	signKey, err := sign.GenerateKey(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,7 +224,7 @@ func testVerifyAuthPath(t *testing.T) {
 }
 
 func testVerifyProofOfAbsenceSamePrefix(t *testing.T) {
-	signKey, err := sign.GenerateKey()
+	signKey, err := sign.GenerateKey(nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/crypto/sign/sign.go
+++ b/crypto/sign/sign.go
@@ -2,6 +2,7 @@ package sign
 
 import (
 	"crypto/rand"
+	"io"
 
 	"golang.org/x/crypto/ed25519"
 )
@@ -15,8 +16,11 @@ const (
 type PrivateKey ed25519.PrivateKey
 type PublicKey ed25519.PublicKey
 
-func GenerateKey() (PrivateKey, error) {
-	_, sk, err := ed25519.GenerateKey(rand.Reader)
+func GenerateKey(rnd io.Reader) (PrivateKey, error) {
+	if rnd == nil {
+		rnd = rand.Reader
+	}
+	_, sk, err := ed25519.GenerateKey(rnd)
 	return PrivateKey(sk), err
 }
 

--- a/crypto/sign/sign_test.go
+++ b/crypto/sign/sign_test.go
@@ -6,7 +6,7 @@ import (
 
 // copied from official crypto.ed25519 tests
 func TestVerifySignature(t *testing.T) {
-	key, err := GenerateKey()
+	key, err := GenerateKey(nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/merkletree/pad_test.go
+++ b/merkletree/pad_test.go
@@ -7,15 +7,16 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"github.com/coniks-sys/coniks-go/crypto/sign"
 	"io"
+
+	"github.com/coniks-sys/coniks-go/crypto/sign"
 )
 
 var signKey sign.PrivateKey
 
 func init() {
 	var err error
-	signKey, err = sign.GenerateKey()
+	signKey, err = sign.GenerateKey(nil)
 	if err != nil {
 		panic(err)
 	}

--- a/merkletree/policy.go
+++ b/merkletree/policy.go
@@ -1,8 +1,6 @@
 package merkletree
 
 import (
-	"reflect"
-
 	"github.com/coniks-sys/coniks-go/crypto"
 	"github.com/coniks-sys/coniks-go/crypto/vrf"
 	"github.com/coniks-sys/coniks-go/utils"
@@ -11,7 +9,6 @@ import (
 type TimeStamp uint64
 
 type Policies interface {
-	Iterate() map[string][]byte
 	Serialize() []byte
 	vrfPrivate() *vrf.PrivateKey
 }
@@ -20,6 +17,7 @@ type ConiksPolicies struct {
 	LibVersion    string
 	HashID        string
 	vrfPrivateKey *vrf.PrivateKey
+	VrfPubKey     []byte
 	EpochDeadline TimeStamp
 }
 
@@ -30,29 +28,9 @@ func NewPolicies(epDeadline TimeStamp, vrfPrivKey *vrf.PrivateKey) Policies {
 		LibVersion:    Version,
 		HashID:        crypto.HashID,
 		vrfPrivateKey: vrfPrivKey,
+		VrfPubKey:     vrfPrivKey.Public(),
 		EpochDeadline: epDeadline,
 	}
-}
-
-// Iterate returns a map of exported fields' name to their values
-func (p *ConiksPolicies) Iterate() map[string][]byte {
-	s := reflect.ValueOf(p).Elem()
-	typeOfT := s.Type()
-	fields := make(map[string][]byte, s.NumField())
-	for i := 0; i < s.NumField(); i++ {
-		f := s.Field(i)
-		if !f.CanInterface() {
-			continue
-		}
-		switch f.Interface().(type) {
-		case string:
-			fields[typeOfT.Field(i).Name] = []byte(f.Interface().(string))
-		case TimeStamp:
-			fields[typeOfT.Field(i).Name] = util.ULongToBytes(uint64(f.Interface().(TimeStamp)))
-		}
-	}
-	fields["VRFPublic"] = p.vrfPrivateKey.Public()
-	return fields
 }
 
 // Serialize encodes the policy to a byte array with the following format:

--- a/utils/coname.go
+++ b/utils/coname.go
@@ -14,6 +14,15 @@
 
 package util
 
+import (
+	"io/ioutil"
+	"os"
+
+	"github.com/coniks-sys/coniks-go/storage/kv"
+	"github.com/coniks-sys/coniks-go/storage/kv/leveldbkv"
+	"github.com/syndtr/goleveldb/leveldb"
+)
+
 // In each byte, the bits are ordered MSB to LSB
 func ToBytes(bits []bool) []byte {
 	bs := make([]byte, (len(bits)+7)/8)
@@ -32,4 +41,18 @@ func ToBits(bs []byte) []bool {
 		bits[i] = (bs[i/8]<<uint(i%8))&(1<<7) > 0
 	}
 	return bits
+}
+
+func WithDB(f func(kv.DB)) {
+	dir, err := ioutil.TempDir("", "merkletree")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+	db, err := leveldb.OpenFile(dir, nil)
+	if err != nil {
+		panic(err)
+	}
+	defer db.Close()
+	f(leveldbkv.Wrap(db))
 }

--- a/utils/util.go
+++ b/utils/util.go
@@ -1,6 +1,12 @@
 package util
 
-import "encoding/binary"
+import (
+	"bytes"
+	"encoding/binary"
+	"io/ioutil"
+	"log"
+	"os"
+)
 
 // GetNthBit finds the bit in the byte array bs
 // at offset offset, and determines whether it is 1 or 0.
@@ -34,4 +40,23 @@ func IntToBytes(num int) []byte {
 	buf := make([]byte, 4)
 	binary.LittleEndian.PutUint32(buf, uint32(num))
 	return buf
+}
+
+func BoolToByte(b bool) byte {
+	if b {
+		return 1
+	}
+	return 0
+}
+
+func WriteFile(filename string, buf bytes.Buffer) {
+	if _, err := os.Stat(filename); err == nil {
+		log.Printf("%s already exists\n", filename)
+		return
+	}
+
+	if err := ioutil.WriteFile(filename, []byte(buf.String()), 0644); err != nil {
+		log.Printf(err.Error())
+		return
+	}
 }


### PR DESCRIPTION
This pull is a part of #29. It includes following changes:
* Remove unnecessary method from `merkletree/policy.go`.
* Add new functions to `util` package.
* `sign.GenerateKey` should take a reader as `vrf`.