### PR TITLE
Align sign and vrf package

### DIFF
--- a/client/cgo/cgotest.go
+++ b/client/cgo/cgotest.go
@@ -75,13 +75,17 @@ func byteSliceToCcharPtr(buf []byte) *C.char {
 }
 
 func testVerifyVrf(t *testing.T) {
-	pk, sk, err := vrf.GenerateKey(nil)
+	sk, err := vrf.GenerateKey(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 	alice := []byte("alice")
 	aliceVRF, aliceProof := sk.Prove(alice)
-	if v := C.testVerifyVrf(byteSliceToCucharPtr(pk[:]), C.int(len(pk)),
+	pk, ok := sk.Public()
+	if !ok {
+		t.Fatal("Couldn't obtain public key!")
+	}
+	if v := C.testVerifyVrf(byteSliceToCucharPtr(pk), C.int(len(pk)),
 		byteSliceToCucharPtr(alice), C.int(len(alice)),
 		byteSliceToCucharPtr(aliceVRF), C.int(len(aliceVRF)),
 		byteSliceToCucharPtr(aliceProof), C.int(len(aliceProof))); v != 1 {
@@ -115,7 +119,7 @@ func testVerifyHashChain(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, vrfPrivKey, err := vrf.GenerateKey(nil)
+	vrfPrivKey, err := vrf.GenerateKey(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -144,7 +148,7 @@ func testVerifyAuthPath(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, vrfPrivKey, err := vrf.GenerateKey(bytes.NewReader(
+	vrfPrivKey, err := vrf.GenerateKey(bytes.NewReader(
 		[]byte("deterministic tests need 256 bit")))
 	if err != nil {
 		t.Fatal(err)
@@ -228,7 +232,7 @@ func testVerifyProofOfAbsenceSamePrefix(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	_, vrfPrivKey, err := vrf.GenerateKey(bytes.NewReader(
+	vrfPrivKey, err := vrf.GenerateKey(bytes.NewReader(
 		[]byte("deterministic tests need 256 bit")))
 	if err != nil {
 		t.Fatal(err)

--- a/client/cgo/verification.go
+++ b/client/cgo/verification.go
@@ -46,8 +46,7 @@ func cgoVerifyVrf(pk unsafe.Pointer, pkSize C.int,
 	mBytes := C.GoBytes(m, size)
 	vrfBytes := C.GoBytes(index, indexSize)
 	proofBytes := C.GoBytes(proof, proofSize)
-	var key vrf.PublicKey
-	copy(key[:], pkBytes)
+	key := vrf.PublicKey(pkBytes)
 	if key.Verify(mBytes, vrfBytes, proofBytes) {
 		return 1
 	}

--- a/crypto/sign/sign.go
+++ b/crypto/sign/sign.go
@@ -24,15 +24,15 @@ func GenerateKey(rnd io.Reader) (PrivateKey, error) {
 	return PrivateKey(sk), err
 }
 
-func (key *PrivateKey) Sign(message []byte) []byte {
-	return ed25519.Sign(ed25519.PrivateKey(*key), message)
+func (key PrivateKey) Sign(message []byte) []byte {
+	return ed25519.Sign(ed25519.PrivateKey(key), message)
 }
 
-func (key *PrivateKey) Public() (PublicKey, bool) {
-	pk, ok := ed25519.PrivateKey(*key).Public().(ed25519.PublicKey)
+func (key PrivateKey) Public() (PublicKey, bool) {
+	pk, ok := ed25519.PrivateKey(key).Public().(ed25519.PublicKey)
 	return PublicKey(pk), ok
 }
 
-func (pk *PublicKey) Verify(message, sig []byte) bool {
-	return ed25519.Verify(ed25519.PublicKey(*pk), message, sig)
+func (pk PublicKey) Verify(message, sig []byte) bool {
+	return ed25519.Verify(ed25519.PublicKey(pk), message, sig)
 }

--- a/crypto/sign/sign_test.go
+++ b/crypto/sign/sign_test.go
@@ -1,6 +1,7 @@
 package sign
 
 import (
+	"bytes"
 	"testing"
 )
 
@@ -26,5 +27,20 @@ func TestVerifySignature(t *testing.T) {
 	wrongMessage := []byte("wrong message")
 	if pk.Verify(wrongMessage, sig) {
 		t.Errorf("signature of different message accepted")
+	}
+}
+
+func TestConvertPrivateKeyToPublicKey(t *testing.T) {
+	sk, err := GenerateKey(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	pk, ok := sk.Public()
+	if !ok {
+		t.Fatal("Couldn't obtain public key.")
+	}
+	if !bytes.Equal(pk, sk[32:]) {
+		t.Fatal("Raw byte respresentation doesn't match public key.")
 	}
 }

--- a/crypto/vrf/vrf.go
+++ b/crypto/vrf/vrf.go
@@ -37,20 +37,19 @@ const (
 	ProofSize        = 32 + 32 + intermediateSize
 )
 
-type PrivateKey [PrivateKeySize]byte
-type PublicKey [PublicKeySize]byte
+type PrivateKey []byte
+type PublicKey []byte
 
 // GenerateKey creates a public/private key pair. rnd is used for randomness.
 // If it is nil, `crypto/rand` is used.
-func GenerateKey(rnd io.Reader) (pk *PublicKey, sk *PrivateKey, err error) {
+func GenerateKey(rnd io.Reader) (sk PrivateKey, err error) {
 	if rnd == nil {
 		rnd = rand.Reader
 	}
-	sk = new(PrivateKey)
-	pk = new(PublicKey)
+	sk = make([]byte, 64)
 	_, err = io.ReadFull(rnd, sk[:32])
 	if err != nil {
-		return nil, nil, err
+		return
 	}
 	x, _ := sk.expandSecret()
 
@@ -60,15 +59,15 @@ func GenerateKey(rnd io.Reader) (pk *PublicKey, sk *PrivateKey, err error) {
 	pkP.ToBytes(&pkBytes)
 
 	copy(sk[32:], pkBytes[:])
-	copy(pk[:], pkBytes[:])
-	return pk, sk, err
+	return
 }
 
-func (sk *PrivateKey) Public() []byte {
-	return ed25519.PrivateKey(sk[:]).Public().(ed25519.PublicKey)
+func (sk *PrivateKey) Public() (PublicKey, bool) {
+	pk, ok := ed25519.PrivateKey(*sk).Public().(ed25519.PublicKey)
+	return PublicKey(pk), ok
 }
 
-func (sk *PrivateKey) expandSecret() (x, skhr *[32]byte) {
+func (sk PrivateKey) expandSecret() (x, skhr *[32]byte) {
 	x, skhr = new([32]byte), new([32]byte)
 	hash := sha3.NewShake256()
 	hash.Write(sk[:32])
@@ -80,7 +79,7 @@ func (sk *PrivateKey) expandSecret() (x, skhr *[32]byte) {
 	return
 }
 
-func (sk *PrivateKey) Compute(m []byte) []byte {
+func (sk PrivateKey) Compute(m []byte) []byte {
 	x, _ := sk.expandSecret()
 	var ii edwards25519.ExtendedGroupElement
 	var iiB [32]byte
@@ -109,7 +108,7 @@ func hashToCurve(m []byte) *edwards25519.ExtendedGroupElement {
 
 // Prove returns the vrf value and a proof such that Verify(pk, m, vrf, proof)
 // == true. The vrf value is the same as returned by Compute(m, sk).
-func (sk *PrivateKey) Prove(m []byte) (vrf, proof []byte) {
+func (sk PrivateKey) Prove(m []byte) (vrf, proof []byte) {
 	x, skhr := sk.expandSecret()
 	var cH, rH [64]byte
 	var r, c, minusC, t, grB, hrB, iiB [32]byte
@@ -155,8 +154,8 @@ func (sk *PrivateKey) Prove(m []byte) (vrf, proof []byte) {
 }
 
 // Verify returns true iff vrf=Compute(m, sk) for the sk that corresponds to pk.
-func (pkBytes *PublicKey) Verify(m, vrfBytes, proof []byte) bool {
-	if len(proof) != ProofSize || len(vrfBytes) != Size || len(*pkBytes) != PublicKeySize {
+func (pkBytes PublicKey) Verify(m, vrfBytes, proof []byte) bool {
+	if len(proof) != ProofSize || len(vrfBytes) != Size || len(pkBytes) != PublicKeySize {
 		return false
 	}
 	var pk, c, cRef, t, vrf, iiB, ABytes, BBytes [32]byte

--- a/crypto/vrf/vrf.go
+++ b/crypto/vrf/vrf.go
@@ -62,8 +62,8 @@ func GenerateKey(rnd io.Reader) (sk PrivateKey, err error) {
 	return
 }
 
-func (sk *PrivateKey) Public() (PublicKey, bool) {
-	pk, ok := ed25519.PrivateKey(*sk).Public().(ed25519.PublicKey)
+func (sk PrivateKey) Public() (PublicKey, bool) {
+	pk, ok := ed25519.PrivateKey(sk).Public().(ed25519.PublicKey)
 	return PublicKey(pk), ok
 }
 

--- a/crypto/vrf/vrf_test.go
+++ b/crypto/vrf/vrf_test.go
@@ -7,10 +7,11 @@ import (
 )
 
 func TestHonestComplete(t *testing.T) {
-	pk, sk, err := GenerateKey(nil)
+	sk, err := GenerateKey(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	pk, _ := sk.Public()
 	alice := []byte("alice")
 	aliceVRF := sk.Compute(alice)
 	aliceVRFFromProof, aliceProof := sk.Prove(alice)
@@ -29,23 +30,27 @@ func TestHonestComplete(t *testing.T) {
 	}
 }
 
-func TestConvertSecretKeyToPublicKey(t *testing.T) {
-	pk, sk, err := GenerateKey(nil)
+func TestConvertPrivateKeyToPublicKey(t *testing.T) {
+	sk, err := GenerateKey(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	pkBytes := sk.Public()
-	if !bytes.Equal(pk[:], pkBytes) {
+	pk, ok := sk.Public()
+	if !ok {
 		t.Fatal("Couldn't obtain public key.")
+	}
+	if !bytes.Equal(sk[32:], pk) {
+		t.Fatal("Raw byte respresentation doesn't match public key.")
 	}
 }
 
 func TestFlipBitForgery(t *testing.T) {
-	pk, sk, err := GenerateKey(nil)
+	sk, err := GenerateKey(nil)
 	if err != nil {
 		t.Fatal(err)
 	}
+	pk, _ := sk.Public()
 	alice := []byte("alice")
 	for i := 0; i < 32; i++ {
 		for j := uint(0); j < 8; j++ {
@@ -96,23 +101,23 @@ func sampleVectorTest(pk PublicKey, aliceVRF, aliceProof []byte, t *testing.T) {
 func TestSampleVectorSets(t *testing.T) {
 
 	var aliceVRF, aliceProof []byte
-	var pk [PublicKeySize]byte
+	var pk []byte
 
 	// Following sets of test vectors are collected from TestHonestComplete(),
 	// and are used for testing the JS implementation of vrf.verify()
 	// Reference: https://github.com/yahoo/end-to-end/pull/58
 
-	pk = [PublicKeySize]byte{194, 191, 96, 139, 106, 249, 24, 253, 198, 131, 88, 169, 100, 231, 7, 211, 70, 171, 171, 207, 24, 30, 150, 114, 77, 124, 240, 123, 191, 14, 29, 111}
+	pk = []byte{194, 191, 96, 139, 106, 249, 24, 253, 198, 131, 88, 169, 100, 231, 7, 211, 70, 171, 171, 207, 24, 30, 150, 114, 77, 124, 240, 123, 191, 14, 29, 111}
 	aliceVRF = []byte{68, 98, 55, 78, 153, 189, 11, 15, 8, 238, 132, 5, 53, 28, 232, 22, 222, 98, 21, 139, 89, 67, 111, 197, 213, 75, 86, 226, 178, 71, 245, 159}
 	aliceProof = []byte{49, 128, 4, 253, 103, 241, 164, 51, 21, 45, 168, 55, 18, 103, 22, 233, 245, 136, 242, 238, 113, 218, 160, 122, 129, 89, 72, 103, 250, 222, 3, 3, 239, 235, 93, 98, 173, 115, 168, 24, 222, 165, 186, 224, 138, 76, 201, 237, 130, 201, 47, 18, 191, 24, 61, 80, 113, 139, 246, 233, 23, 94, 177, 12, 193, 106, 38, 172, 66, 192, 22, 188, 177, 14, 144, 100, 38, 179, 96, 70, 55, 157, 80, 139, 145, 62, 94, 195, 181, 224, 183, 42, 64, 66, 145, 162}
 	sampleVectorTest(pk, aliceVRF, aliceProof, t)
 
-	pk = [PublicKeySize]byte{133, 36, 180, 21, 60, 103, 35, 92, 204, 245, 236, 174, 242, 50, 212, 69, 124, 230, 1, 106, 94, 95, 201, 55, 208, 252, 195, 13, 12, 96, 87, 170}
+	pk = []byte{133, 36, 180, 21, 60, 103, 35, 92, 204, 245, 236, 174, 242, 50, 212, 69, 124, 230, 1, 106, 94, 95, 201, 55, 208, 252, 195, 13, 12, 96, 87, 170}
 	aliceVRF = []byte{35, 127, 188, 177, 246, 242, 213, 46, 16, 72, 1, 196, 69, 181, 160, 204, 69, 230, 17, 147, 251, 207, 203, 184, 154, 122, 118, 10, 144, 76, 229, 234}
 	aliceProof = []byte{253, 33, 80, 241, 250, 172, 198, 28, 16, 171, 161, 194, 110, 175, 158, 233, 250, 89, 35, 174, 221, 101, 98, 136, 32, 191, 82, 127, 92, 208, 199, 10, 123, 46, 70, 95, 56, 102, 63, 137, 53, 160, 128, 216, 134, 152, 87, 58, 19, 244, 167, 108, 144, 13, 97, 232, 207, 75, 107, 57, 193, 124, 231, 5, 242, 122, 182, 247, 155, 187, 86, 165, 114, 46, 188, 52, 21, 121, 238, 100, 85, 32, 119, 116, 250, 208, 32, 60, 145, 53, 145, 76, 84, 153, 185, 28}
 	sampleVectorTest(pk, aliceVRF, aliceProof, t)
 
-	pk = [PublicKeySize]byte{85, 126, 176, 228, 114, 43, 110, 223, 111, 129, 204, 38, 215, 110, 165, 148, 223, 232, 79, 254, 150, 107, 61, 29, 216, 14, 238, 104, 55, 163, 121, 185}
+	pk = []byte{85, 126, 176, 228, 114, 43, 110, 223, 111, 129, 204, 38, 215, 110, 165, 148, 223, 232, 79, 254, 150, 107, 61, 29, 216, 14, 238, 104, 55, 163, 121, 185}
 	aliceVRF = []byte{171, 240, 42, 215, 128, 5, 247, 64, 164, 154, 198, 231, 6, 174, 207, 10, 95, 231, 117, 189, 88, 103, 72, 229, 43, 218, 184, 162, 44, 183, 196, 159}
 	aliceProof = []byte{99, 103, 243, 119, 251, 30, 21, 57, 69, 162, 192, 80, 7, 49, 244, 136, 13, 252, 150, 165, 215, 181, 55, 203, 141, 124, 197, 36, 20, 183, 239, 14, 238, 213, 240, 96, 181, 187, 24, 137, 152, 152, 38, 186, 80, 141, 72, 15, 209, 178, 60, 205, 22, 31, 101, 185, 225, 159, 22, 118, 84, 179, 95, 0, 124, 140, 237, 187, 8, 77, 233, 213, 207, 211, 251, 153, 71, 112, 61, 89, 53, 26, 195, 167, 254, 73, 218, 135, 145, 89, 12, 4, 16, 255, 63, 89}
 	sampleVectorTest(pk, aliceVRF, aliceProof, t)
@@ -128,7 +133,7 @@ func BenchmarkHashToGE(b *testing.B) {
 }
 
 func BenchmarkCompute(b *testing.B) {
-	_, sk, err := GenerateKey(nil)
+	sk, err := GenerateKey(nil)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -140,7 +145,7 @@ func BenchmarkCompute(b *testing.B) {
 }
 
 func BenchmarkProve(b *testing.B) {
-	_, sk, err := GenerateKey(nil)
+	sk, err := GenerateKey(nil)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -152,13 +157,14 @@ func BenchmarkProve(b *testing.B) {
 }
 
 func BenchmarkVerify(b *testing.B) {
-	pk, sk, err := GenerateKey(nil)
+	sk, err := GenerateKey(nil)
 	if err != nil {
 		b.Fatal(err)
 	}
 	alice := []byte("alice")
 	aliceVRF := sk.Compute(alice)
 	_, aliceProof := sk.Prove(alice)
+	pk, _ := sk.Public()
 	b.ResetTimer()
 	for n := 0; n < b.N; n++ {
 		pk.Verify(alice, aliceVRF, aliceProof)

--- a/merkletree/merkletree_test.go
+++ b/merkletree/merkletree_test.go
@@ -9,10 +9,10 @@ import (
 	"golang.org/x/crypto/sha3"
 )
 
-var _, vrfPrivKey1, _ = vrf.GenerateKey(bytes.NewReader(
+var vrfPrivKey1, _ = vrf.GenerateKey(bytes.NewReader(
 	[]byte("deterministic tests need 256 bit")))
 
-var _, vrfPrivKey2, _ = vrf.GenerateKey(bytes.NewReader(
+var vrfPrivKey2, _ = vrf.GenerateKey(bytes.NewReader(
 	[]byte("deterministic tests need 32 byte")))
 
 func TestOneEntry(t *testing.T) {

--- a/merkletree/pad.go
+++ b/merkletree/pad.go
@@ -70,9 +70,9 @@ func (pad *PAD) updateInternal(policies Policies, epoch uint64) {
 	pad.loadedEpochs = append(pad.loadedEpochs, epoch)
 
 	if policies != nil { // update the policies if necessary
-		vrfKeyChanged := 1 != (subtle.ConstantTimeCompare(
-			pad.policies.vrfPrivate()[:],
-			policies.vrfPrivate()[:]))
+		vrfKeyChanged := 1 != subtle.ConstantTimeCompare(
+			pad.policies.vrfPrivate(),
+			policies.vrfPrivate())
 		pad.policies = policies
 		if vrfKeyChanged {
 			pad.reshuffle()
@@ -151,7 +151,7 @@ func (pad *PAD) reshuffle() {
 }
 
 func (pad *PAD) computePrivateIndex(name string,
-	vrfPrivKey *vrf.PrivateKey) (index, proof []byte) {
+	vrfPrivKey vrf.PrivateKey) (index, proof []byte) {
 	index, proof = vrfPrivKey.Prove([]byte(name))
 	return
 }

--- a/merkletree/policy.go
+++ b/merkletree/policy.go
@@ -10,25 +10,29 @@ type TimeStamp uint64
 
 type Policies interface {
 	Serialize() []byte
-	vrfPrivate() *vrf.PrivateKey
+	vrfPrivate() vrf.PrivateKey
 }
 
 type ConiksPolicies struct {
 	LibVersion    string
 	HashID        string
-	vrfPrivateKey *vrf.PrivateKey
+	vrfPrivateKey vrf.PrivateKey
 	VrfPubKey     []byte
 	EpochDeadline TimeStamp
 }
 
 var _ Policies = (*ConiksPolicies)(nil)
 
-func NewPolicies(epDeadline TimeStamp, vrfPrivKey *vrf.PrivateKey) Policies {
+func NewPolicies(epDeadline TimeStamp, vrfPrivKey vrf.PrivateKey) Policies {
+	vrfPublicKey, ok := vrfPrivKey.Public()
+	if !ok {
+		panic("Couldn't get correspoding public-key from private-key")
+	}
 	return &ConiksPolicies{
 		LibVersion:    Version,
 		HashID:        crypto.HashID,
 		vrfPrivateKey: vrfPrivKey,
-		VrfPubKey:     vrfPrivKey.Public(),
+		VrfPubKey:     vrfPublicKey,
 		EpochDeadline: epDeadline,
 	}
 }
@@ -36,14 +40,18 @@ func NewPolicies(epDeadline TimeStamp, vrfPrivKey *vrf.PrivateKey) Policies {
 // Serialize encodes the policy to a byte array with the following format:
 // [lib version, cryptographic algorithm in use, epoch deadline, vrf public key]
 func (p *ConiksPolicies) Serialize() []byte {
+	vrfPublicKey, ok := p.vrfPrivateKey.Public()
+	if !ok {
+		panic("Couldn't get correspoding public-key from private-key")
+	}
 	var bs []byte
 	bs = append(bs, []byte(p.LibVersion)...)                       // lib Version
 	bs = append(bs, []byte(p.HashID)...)                           // cryptographic algorithms in use
 	bs = append(bs, util.ULongToBytes(uint64(p.EpochDeadline))...) // epoch deadline
-	bs = append(bs, p.vrfPrivateKey.Public()...)                   // vrf public key
+	bs = append(bs, vrfPublicKey...)                               // vrf public key
 	return bs
 }
 
-func (p *ConiksPolicies) vrfPrivate() *vrf.PrivateKey {
+func (p *ConiksPolicies) vrfPrivate() vrf.PrivateKey {
 	return p.vrfPrivateKey
 }


### PR DESCRIPTION
- change underlying type for vrf keys to slice of bytes instead of arrays
- GenerateKey in `vrf` and `sign` package have equivalent signatures
- in `vrf` and `sign` `Public()` returns a vrf/sign `PublicKey` type
- deleted `Serialize()` ~~returns a slice of byte~~

Should resolve #65 