### PR TITLE
CloseWrite to indicate end

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
 sudo: false
 language: go
 
+go:
+  - 1.6
+  - tip
+
 before_install:
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover


### PR DESCRIPTION
This should prevent the need for `DynamicRecordSizingDisabled`

I don't think you intended to keep long living tcp connections.  If we want them, we probably need a protocol above that layer, even if it's just sending the length to read in the first byte.