### PR TITLE
Convert Response interface to struct

### DIFF
--- a/keyserver/encoding.go
+++ b/keyserver/encoding.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/coniks-sys/coniks-go/protocol"
 )
 
-func MarshalResponse(response Response) ([]byte, error) {
+func MarshalResponse(response *Response) ([]byte, error) {
 	return json.Marshal(response)
 }
 

--- a/keyserver/server_test.go
+++ b/keyserver/server_test.go
@@ -114,9 +114,6 @@ func TestBotSendsRegistration(t *testing.T) {
 			t.Log(string(rev))
 			t.Fatal(err)
 		}
-		if response.DirectoryResponse.Type != RegistrationType {
-			t.Fatal("Expect a registration response")
-		}
 		if response.Error != Success {
 			t.Fatal("Expect a successful registration", "got", response.Error)
 		}
@@ -280,9 +277,6 @@ func TestRegisterAndLookupInTheSameEpoch(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if response.DirectoryResponse.Type != KeyLookupType {
-			t.Fatal("Expect a key lookup response", "got", response.DirectoryResponse.Type)
-		}
 		if response.Error != Success {
 			t.Fatal("Expect no error", "got", response.Error)
 		}
@@ -328,9 +322,6 @@ func TestRegisterAndLookup(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if res.DirectoryResponse.Type != KeyLookupType {
-			t.Fatal("Expect a key lookup response", "got", res.DirectoryResponse.Type)
-		}
 		if res.Error != Success {
 			t.Fatal("Expect no error", "got", res.Error)
 		}
@@ -375,9 +366,6 @@ func TestKeyLookup(t *testing.T) {
 		err = json.Unmarshal(rev, &response)
 		if err != nil {
 			t.Fatal(err)
-		}
-		if response.DirectoryResponse.Type != KeyLookupType {
-			t.Fatal("Expect a key lookup response", "got", response.DirectoryResponse.Type)
 		}
 		if response.Error != Success {
 			t.Fatal("Expect no error", "got", response.Error)
@@ -436,9 +424,6 @@ func TestKeyLookupInEpoch(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if response.DirectoryResponse.Type != KeyLookupInEpochType {
-			t.Fatal("Expect a key lookup in epoch response", "got", response.DirectoryResponse.Type)
-		}
 		if response.Error != ErrorNameNotFound {
 			t.Fatal("Expect error", ErrorNameNotFound, "got", response.Error)
 		}
@@ -488,9 +473,6 @@ func TestMonitoring(t *testing.T) {
 		err = json.Unmarshal(rev, &response)
 		if err != nil {
 			t.Fatal(err)
-		}
-		if response.DirectoryResponse.Type != MonitoringType {
-			t.Fatal("Expect a consistency check response", "got", response.DirectoryResponse.Type)
 		}
 		if response.Error != Success {
 			t.Fatal("Expect error", Success, "got", response.Error)

--- a/keyserver/testutil/testutil.go
+++ b/keyserver/testutil/testutil.go
@@ -31,19 +31,17 @@ const (
 type ExpectingDirProofResponse struct {
 	Error             protocol.ErrorCode
 	DirectoryResponse struct {
-		Type int
-		AP   json.RawMessage
-		STR  json.RawMessage
-		TB   json.RawMessage
+		AP  json.RawMessage
+		STR json.RawMessage
+		TB  json.RawMessage
 	}
 }
 
 type ExpectingDirProofsResponse struct {
 	Error             protocol.ErrorCode
 	DirectoryResponse struct {
-		Type int
-		AP   []json.RawMessage
-		STR  []json.RawMessage
+		AP  []json.RawMessage
+		STR []json.RawMessage
 	}
 }
 

--- a/keyserver/testutil/testutil.go
+++ b/keyserver/testutil/testutil.go
@@ -8,6 +8,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
+	"encoding/json"
 	"encoding/pem"
 	"io"
 	"io/ioutil"
@@ -17,6 +18,8 @@ import (
 	"path"
 	"testing"
 	"time"
+
+	"github.com/coniks-sys/coniks-go/protocol"
 )
 
 const (
@@ -24,6 +27,29 @@ const (
 	PublicConnection = "127.0.0.1:3000"
 	LocalConnection  = "/tmp/conikstest.sock"
 )
+
+type ExpectingDirProofResponse struct {
+	Error             protocol.ErrorCode
+	DirectoryResponse struct {
+		Type int
+		AP   json.RawMessage
+		STR  json.RawMessage
+		TB   json.RawMessage
+	}
+}
+
+type ExpectingDirProofsResponse struct {
+	Error             protocol.ErrorCode
+	DirectoryResponse struct {
+		Type int
+		AP   []json.RawMessage
+		STR  []json.RawMessage
+	}
+}
+
+type ExpectingSTR struct {
+	Epoch uint64
+}
 
 func CreateTLSCert(dir string) error {
 	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)

--- a/protocol/directory.go
+++ b/protocol/directory.go
@@ -53,7 +53,7 @@ func (d *ConiksDirectory) LatestSTR() *merkletree.SignedTreeRoot {
 
 // HandleOps validates the request message and then pass it to
 // appropriate operation handler according to the request type.
-func (d *ConiksDirectory) HandleOps(req *Request) (Response, ErrorCode) {
+func (d *ConiksDirectory) HandleOps(req *Request) (*Response, ErrorCode) {
 	switch req.Type {
 	case RegistrationType:
 		if msg, ok := req.Request.(*RegistrationRequest); ok {
@@ -85,7 +85,7 @@ func (d *ConiksDirectory) HandleOps(req *Request) (Response, ErrorCode) {
 }
 
 func (d *ConiksDirectory) Register(req *RegistrationRequest) (
-	Response, ErrorCode) {
+	*Response, ErrorCode) {
 	// check whether the name already exists
 	// in the directory before we register
 	ap, err := d.pad.Lookup(req.Username)
@@ -118,7 +118,7 @@ func (d *ConiksDirectory) Register(req *RegistrationRequest) (
 }
 
 func (d *ConiksDirectory) KeyLookup(req *KeyLookupRequest) (
-	Response, ErrorCode) {
+	*Response, ErrorCode) {
 	ap, err := d.pad.Lookup(req.Username)
 	if err != nil {
 		return NewErrorResponse(ErrorDirectory), ErrorDirectory
@@ -137,7 +137,7 @@ func (d *ConiksDirectory) KeyLookup(req *KeyLookupRequest) (
 }
 
 func (d *ConiksDirectory) KeyLookupInEpoch(req *KeyLookupInEpochRequest) (
-	Response, ErrorCode) {
+	*Response, ErrorCode) {
 	var strs []*merkletree.SignedTreeRoot
 	startEp := req.Epoch
 	endEp := d.LatestSTR().Epoch
@@ -158,7 +158,7 @@ func (d *ConiksDirectory) KeyLookupInEpoch(req *KeyLookupInEpochRequest) (
 }
 
 func (d *ConiksDirectory) Monitor(req *MonitoringRequest) (
-	Response, ErrorCode) {
+	*Response, ErrorCode) {
 	var strs []*merkletree.SignedTreeRoot
 	var aps []*merkletree.AuthenticationPath
 	startEp := req.StartEpoch

--- a/protocol/directory_test.go
+++ b/protocol/directory_test.go
@@ -34,9 +34,6 @@ func TestRegisterWithTB(t *testing.T) {
 		Username: "alice",
 		Key:      []byte("key")})
 	df := res.DirectoryResponse.(*DirectoryProof)
-	if df.Type != RegistrationType {
-		t.Fatal("Expect response type", RegistrationType, "got", df.Type)
-	}
 	if err != Success {
 		t.Fatal("Unable to register")
 	}
@@ -155,9 +152,6 @@ func TestKeyLookupWithTB(t *testing.T) {
 	// expect a proof of absence and the TB of looking up user
 	res, _ = d.KeyLookup(&KeyLookupRequest{Username: "alice"})
 	df := res.DirectoryResponse.(*DirectoryProof)
-	if df.Type != KeyLookupType {
-		t.Fatal("Expect response type", KeyLookupType, "got", df.Type)
-	}
 	if res.Error != Success {
 		t.Fatal("Expect no error", "got", res.Error)
 	}
@@ -239,9 +233,6 @@ func TestDirectoryMonitoring(t *testing.T) {
 	// missed from epoch 2
 	res, err := d.Monitor(&MonitoringRequest{"alice", uint64(2), d.LatestSTR().Epoch})
 	df := res.DirectoryResponse.(*DirectoryProofs)
-	if df.Type != MonitoringType {
-		t.Fatal("Expect response type", MonitoringType, "got", df.Type)
-	}
 	if err != Success {
 		t.Fatal("Unable to perform key lookup in epoch", 2)
 	}
@@ -263,9 +254,6 @@ func TestDirectoryMonitoring(t *testing.T) {
 	// assert the number of STRs returned is correct
 	res, err = d.Monitor(&MonitoringRequest{"alice", uint64(2), d.LatestSTR().Epoch + 5})
 	df = res.DirectoryResponse.(*DirectoryProofs)
-	if df.Type != MonitoringType {
-		t.Fatal("Expect response type", MonitoringType, "got", df.Type)
-	}
 	if err != Success {
 		t.Fatal("Unable to perform key lookup in epoch", 2)
 	}
@@ -285,9 +273,6 @@ func TestDirectoryKeyLookupInEpoch(t *testing.T) {
 	// lookup at epoch 1, expect a proof of absence & ErrorNameNotFound
 	res, err := d.KeyLookupInEpoch(&KeyLookupInEpochRequest{"alice", uint64(1)})
 	df := res.DirectoryResponse.(*DirectoryProofs)
-	if df.Type != KeyLookupInEpochType {
-		t.Fatal("Expect response type", KeyLookupInEpochType, "got", df.Type)
-	}
 	if err != ErrorNameNotFound {
 		t.Fatal("Expect error", ErrorNameNotFound, "got", err)
 	}
@@ -307,9 +292,6 @@ func TestDirectoryKeyLookupInEpoch(t *testing.T) {
 
 	res, err = d.KeyLookupInEpoch(&KeyLookupInEpochRequest{"alice", uint64(5)})
 	df = res.DirectoryResponse.(*DirectoryProofs)
-	if df.Type != KeyLookupInEpochType {
-		t.Fatal("Expect response type", KeyLookupInEpochType, "got", df.Type)
-	}
 	if err != Success {
 		t.Fatal("Expect error", Success, "got", err)
 	}

--- a/protocol/message.go
+++ b/protocol/message.go
@@ -60,16 +60,14 @@ type Response struct {
 type DirectoryResponse interface{}
 
 type DirectoryProof struct {
-	Type int
-	AP   *m.AuthenticationPath
-	STR  *m.SignedTreeRoot
-	TB   *m.TemporaryBinding `json:",omitempty"`
+	AP  *m.AuthenticationPath
+	STR *m.SignedTreeRoot
+	TB  *m.TemporaryBinding `json:",omitempty"`
 }
 
 type DirectoryProofs struct {
-	Type int
-	AP   []*m.AuthenticationPath
-	STR  []*m.SignedTreeRoot
+	AP  []*m.AuthenticationPath
+	STR []*m.SignedTreeRoot
 }
 
 func NewErrorResponse(e ErrorCode) *Response {
@@ -81,10 +79,9 @@ func NewRegistrationProof(ap *m.AuthenticationPath, str *m.SignedTreeRoot,
 	return &Response{
 		Error: e,
 		DirectoryResponse: &DirectoryProof{
-			Type: RegistrationType,
-			AP:   ap,
-			STR:  str,
-			TB:   tb,
+			AP:  ap,
+			STR: str,
+			TB:  tb,
 		},
 	}, e
 }
@@ -94,10 +91,9 @@ func NewKeyLookupProof(ap *m.AuthenticationPath, str *m.SignedTreeRoot,
 	return &Response{
 		Error: e,
 		DirectoryResponse: &DirectoryProof{
-			Type: KeyLookupType,
-			AP:   ap,
-			STR:  str,
-			TB:   tb,
+			AP:  ap,
+			STR: str,
+			TB:  tb,
 		},
 	}, e
 }
@@ -108,9 +104,8 @@ func NewKeyLookupInEpochProof(ap *m.AuthenticationPath,
 	return &Response{
 		Error: e,
 		DirectoryResponse: &DirectoryProofs{
-			Type: KeyLookupInEpochType,
-			AP:   aps,
-			STR:  str,
+			AP:  aps,
+			STR: str,
 		},
 	}, e
 }
@@ -120,9 +115,8 @@ func NewMonitoringProof(ap []*m.AuthenticationPath,
 	return &Response{
 		Error: e,
 		DirectoryResponse: &DirectoryProofs{
-			Type: MonitoringType,
-			AP:   ap,
-			STR:  str,
+			AP:  ap,
+			STR: str,
 		},
 	}, e
 }

--- a/protocol/message.go
+++ b/protocol/message.go
@@ -52,48 +52,77 @@ type MonitoringRequest struct {
 }
 
 // Response messages
-type Response interface{}
-
-type ErrorResponse struct {
-	Error ErrorCode
+type Response struct {
+	Error             ErrorCode
+	DirectoryResponse `json:",omitempty"`
 }
 
-func NewErrorResponse(e ErrorCode) Response {
-	return &ErrorResponse{Error: e}
-}
+type DirectoryResponse interface{}
 
 type DirectoryProof struct {
-	Type  int
-	AP    *m.AuthenticationPath
-	STR   *m.SignedTreeRoot
-	TB    *m.TemporaryBinding `json:",omitempty"`
-	Error ErrorCode
+	Type int
+	AP   *m.AuthenticationPath
+	STR  *m.SignedTreeRoot
+	TB   *m.TemporaryBinding `json:",omitempty"`
 }
 
 type DirectoryProofs struct {
-	Type  int
-	AP    []*m.AuthenticationPath
-	STR   []*m.SignedTreeRoot
-	Error ErrorCode
+	Type int
+	AP   []*m.AuthenticationPath
+	STR  []*m.SignedTreeRoot
+}
+
+func NewErrorResponse(e ErrorCode) *Response {
+	return &Response{Error: e}
 }
 
 func NewRegistrationProof(ap *m.AuthenticationPath, str *m.SignedTreeRoot,
-	tb *m.TemporaryBinding, e ErrorCode) (*DirectoryProof, ErrorCode) {
-	return &DirectoryProof{RegistrationType, ap, str, tb, e}, e
+	tb *m.TemporaryBinding, e ErrorCode) (*Response, ErrorCode) {
+	return &Response{
+		Error: e,
+		DirectoryResponse: &DirectoryProof{
+			Type: RegistrationType,
+			AP:   ap,
+			STR:  str,
+			TB:   tb,
+		},
+	}, e
 }
 
 func NewKeyLookupProof(ap *m.AuthenticationPath, str *m.SignedTreeRoot,
-	tb *m.TemporaryBinding, e ErrorCode) (*DirectoryProof, ErrorCode) {
-	return &DirectoryProof{KeyLookupType, ap, str, tb, e}, e
+	tb *m.TemporaryBinding, e ErrorCode) (*Response, ErrorCode) {
+	return &Response{
+		Error: e,
+		DirectoryResponse: &DirectoryProof{
+			Type: KeyLookupType,
+			AP:   ap,
+			STR:  str,
+			TB:   tb,
+		},
+	}, e
 }
 
 func NewKeyLookupInEpochProof(ap *m.AuthenticationPath,
-	str []*m.SignedTreeRoot, e ErrorCode) (*DirectoryProofs, ErrorCode) {
+	str []*m.SignedTreeRoot, e ErrorCode) (*Response, ErrorCode) {
 	aps := append([]*m.AuthenticationPath{}, ap)
-	return &DirectoryProofs{KeyLookupInEpochType, aps, str, e}, e
+	return &Response{
+		Error: e,
+		DirectoryResponse: &DirectoryProofs{
+			Type: KeyLookupInEpochType,
+			AP:   aps,
+			STR:  str,
+		},
+	}, e
 }
 
 func NewMonitoringProof(ap []*m.AuthenticationPath,
-	str []*m.SignedTreeRoot, e ErrorCode) (*DirectoryProofs, ErrorCode) {
-	return &DirectoryProofs{MonitoringType, ap, str, e}, e
+	str []*m.SignedTreeRoot, e ErrorCode) (*Response, ErrorCode) {
+	return &Response{
+		Error: e,
+		DirectoryResponse: &DirectoryProofs{
+			Type: MonitoringType,
+			AP:   ap,
+			STR:  str,
+		},
+	}, e
 }


### PR DESCRIPTION
- Convert `Response` interface to a struct like `Request`
- Refactor server_test.go code