### PR TITLE
Only update policies immediately after epoch

### DIFF
--- a/keyserver/server_test.go
+++ b/keyserver/server_test.go
@@ -332,7 +332,7 @@ func TestRegisterAndLookup(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		server.dir.Update()
+		server.dir.Update(nil)
 		rev, err := testutil.NewTCPClient([]byte(keylookupMsg))
 		if err != nil {
 			t.Fatal(err)
@@ -389,7 +389,7 @@ func TestKeyLookup(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		server.dir.Update()
+		server.dir.Update(nil)
 		rev, err := testutil.NewTCPClient([]byte(keylookupMsg))
 		if err != nil {
 			t.Fatal(err)
@@ -442,7 +442,7 @@ func TestKeyLookupInEpoch(t *testing.T) {
 		defer teardown()
 
 		for i := 0; i < 3; i++ {
-			server.dir.Update()
+			server.dir.Update(nil)
 		}
 		_, err := testutil.NewUnixClient([]byte(registrationMsg))
 		if err != nil {
@@ -509,7 +509,7 @@ func TestMonitoring(t *testing.T) {
 		latestSTR, _, _ := getSTRFromResponse(t, regResponse.STR)
 
 		for i := 0; i < N; i++ {
-			server.dir.Update()
+			server.dir.Update(nil)
 		}
 
 		var consistencyCheckMsg = `

--- a/protocol/directory.go
+++ b/protocol/directory.go
@@ -15,10 +15,15 @@ type ConiksDirectory struct {
 	policies merkletree.Policies
 }
 
+type UpdatePolicies struct {
+	EpDeadline merkletree.TimeStamp
+	VrfKey     vrf.PrivateKey
+}
+
 func InitDirectory(epDeadline merkletree.TimeStamp, vrfKey vrf.PrivateKey,
 	signKey sign.PrivateKey, dirSize uint64, useTBs bool) *ConiksDirectory {
 	d := new(ConiksDirectory)
-	d.SetPolicies(epDeadline, vrfKey)
+	d.setPolicies(epDeadline, vrfKey)
 	pad, err := merkletree.NewPAD(d.policies, signKey, dirSize)
 	if err != nil {
 		panic(err)
@@ -31,15 +36,18 @@ func InitDirectory(epDeadline merkletree.TimeStamp, vrfKey vrf.PrivateKey,
 	return d
 }
 
-func (d *ConiksDirectory) Update() {
+func (d *ConiksDirectory) Update(up *UpdatePolicies) {
 	d.pad.Update(d.policies)
 	// clear issued temporary bindings
 	for key := range d.tbs {
 		delete(d.tbs, key)
 	}
+	if up != nil {
+		d.setPolicies(up.EpDeadline, up.VrfKey)
+	}
 }
 
-func (d *ConiksDirectory) SetPolicies(epDeadline merkletree.TimeStamp, vrfKey vrf.PrivateKey) {
+func (d *ConiksDirectory) setPolicies(epDeadline merkletree.TimeStamp, vrfKey vrf.PrivateKey) {
 	d.policies = merkletree.NewPolicies(epDeadline, vrfKey)
 }
 

--- a/protocol/directory_test.go
+++ b/protocol/directory_test.go
@@ -49,7 +49,7 @@ func TestRegisterWithTB(t *testing.T) {
 	if d.tbs["alice"] == nil {
 		t.Fatal("Expect TBs array has registering user")
 	}
-	d.Update()
+	d.Update(nil)
 	if len(d.tbs) != 0 {
 		t.Fatal("Expect TBs array is empty")
 	}
@@ -81,7 +81,7 @@ func TestRegisterExistedUserWithTB(t *testing.T) {
 		t.Fatal("Expect returned TB is not nil")
 	}
 
-	d.Update()
+	d.Update(nil)
 	// register in different epochs
 	// expect return a proof of inclusion
 	// and error ErrorNameExisted
@@ -127,7 +127,7 @@ func TestRegisterExistedUserWithoutTB(t *testing.T) {
 		t.Fatal("Unable to register")
 	}
 
-	d.Update()
+	d.Update(nil)
 	// expect return a proof of inclusion
 	// and error ErrorNameExisted
 	res, err := d.Register(&RegistrationRequest{
@@ -174,7 +174,7 @@ func TestKeyLookupWithTB(t *testing.T) {
 		t.Fatal("Expect the same TB for the registration and lookup")
 	}
 
-	d.Update()
+	d.Update(nil)
 	// lookup in epoch after registering epoch
 	// expect a proof of inclusion
 	res, _ = d.KeyLookup(&KeyLookupRequest{Username: "alice"})
@@ -209,7 +209,7 @@ func TestKeyLookupWithoutTB(t *testing.T) {
 		t.Fatal("Expect returned TB is nil")
 	}
 
-	d.Update()
+	d.Update(nil)
 	// lookup in epoch after registering epoch
 	// expect a proof of inclusion
 	res, err = d.KeyLookup(&KeyLookupRequest{Username: "alice"})
@@ -230,10 +230,10 @@ func TestDirectoryMonitoring(t *testing.T) {
 		Username: "alice",
 		Key:      []byte("key")})
 
-	d.Update()
+	d.Update(nil)
 	savedSTR := d.LatestSTR().Signature
 	for i := 2; i < N; i++ {
-		d.Update()
+		d.Update(nil)
 	}
 
 	// missed from epoch 2
@@ -279,7 +279,7 @@ func TestDirectoryKeyLookupInEpoch(t *testing.T) {
 
 	d := newDirectory(t, false)
 	for i := 0; i < N; i++ {
-		d.Update()
+		d.Update(nil)
 	}
 
 	// lookup at epoch 1, expect a proof of absence & ErrorNameNotFound
@@ -302,7 +302,7 @@ func TestDirectoryKeyLookupInEpoch(t *testing.T) {
 		Username: "alice",
 		Key:      []byte("key")})
 	for i := 0; i < N; i++ {
-		d.Update()
+		d.Update(nil)
 	}
 
 	res, err = d.KeyLookupInEpoch(&KeyLookupInEpochRequest{"alice", uint64(5)})


### PR DESCRIPTION
TBs are handed out with the current vrf key.  If it's swapped afterwards, the indices won't matchup at the next epoch.

Not sure how crazy I am about the `UpdatePolicies` struct.  This is more about identifying the issue.