### PR TITLE
ConiksDirectory.EpochDeadline() should return EpochDeadline from the PAD's Policies

### DIFF
--- a/protocol/directory.go
+++ b/protocol/directory.go
@@ -44,7 +44,7 @@ func (d *ConiksDirectory) SetPolicies(epDeadline merkletree.TimeStamp, vrfKey vr
 }
 
 func (d *ConiksDirectory) EpochDeadline() merkletree.TimeStamp {
-	return d.policies.EpDeadline()
+	return d.pad.LatestSTR().Policies.EpDeadline()
 }
 
 func (d *ConiksDirectory) LatestSTR() *merkletree.SignedTreeRoot {


### PR DESCRIPTION
If the developers want to query `EpochDeadline` before the new policies is updated, `ConiksDirectory.EpochDeadline()` should return the `EpochDeadline` from the pad's policies instead of the current policies of the directory.

