### PR TITLE
Key-value DB using `gob` for encoding/decoding

### DIFF
--- a/merkletree/merkletree_test.go
+++ b/merkletree/merkletree_test.go
@@ -39,10 +39,10 @@ func TestOneEntry(t *testing.T) {
 	h.Write(utils.ToBytes([]bool{true}))
 	h.Write(utils.UInt32ToBytes(1))
 	h.Read(expect[:])
-	if !bytes.Equal(m.root.rightHash, expect[:]) {
+	if !bytes.Equal(m.root.RightHash, expect[:]) {
 		t.Error("Wrong righ hash!",
 			"expected", expect,
-			"get", m.root.rightHash)
+			"get", m.root.RightHash)
 	}
 
 	r := m.Get(index)
@@ -70,10 +70,10 @@ func TestOneEntry(t *testing.T) {
 	h.Write(commit[:])
 	h.Read(expect[:])
 
-	if !bytes.Equal(m.root.leftHash, expect[:]) {
+	if !bytes.Equal(m.root.LeftHash, expect[:]) {
 		t.Error("Wrong left hash!",
 			"expected", expect,
-			"get", m.root.leftHash)
+			"get", m.root.LeftHash)
 	}
 
 	r = m.Get([]byte("abc"))

--- a/merkletree/mock_ad.go
+++ b/merkletree/mock_ad.go
@@ -1,0 +1,15 @@
+package merkletree
+
+import "encoding/gob"
+
+func init() {
+	gob.Register(&MockAd{})
+}
+
+type MockAd struct {
+	Data string
+}
+
+func (t *MockAd) Serialize() []byte {
+	return []byte(t.Data)
+}

--- a/storage/kv/merkletreekv/doc.go
+++ b/storage/kv/merkletreekv/doc.go
@@ -1,0 +1,5 @@
+/*
+Package merkletreekv implements the database backend hook
+for package merkletree.
+*/
+package merkletreekv

--- a/storage/kv/merkletreekv/identifier.go
+++ b/storage/kv/merkletreekv/identifier.go
@@ -1,0 +1,8 @@
+package merkletreekv
+
+const (
+	// STRIdentifier is the domain separation for STR.
+	STRIdentifier = 'S'
+	// PADIdentifier is the domain separation for PAD.
+	PADIdentifier = 'O'
+)

--- a/storage/kv/merkletreekv/padkv.go
+++ b/storage/kv/merkletreekv/padkv.go
@@ -1,0 +1,33 @@
+package merkletreekv
+
+import (
+	"bytes"
+
+	"github.com/coniks-sys/coniks-go/merkletree"
+	"github.com/coniks-sys/coniks-go/storage/kv"
+)
+
+// StorePAD stores pad to the db.
+// StorePAD uses the same key to store the PAD, so the old PAD
+// would be replaced by the newly stored PAD.
+func StorePAD(db kv.DB, pad *merkletree.PAD) error {
+	wb := db.NewBatch()
+	buff := new(bytes.Buffer)
+	if err := merkletree.EncodePAD(buff, pad); err != nil {
+		return err
+	}
+	wb.Put([]byte{PADIdentifier}, buff.Bytes())
+	return db.Write(wb)
+}
+
+// LoadPAD reconstructs the PAD stored in the db.
+// It requires the caller pass the maximum capacity
+// for the snapshot cache length.
+func LoadPAD(db kv.DB, length uint64) (*merkletree.PAD, error) {
+	bbuff, err := db.Get([]byte{PADIdentifier})
+	if err != nil {
+		return nil, err
+	}
+	buff := bytes.NewBuffer(bbuff)
+	return merkletree.DecodePAD(length, buff)
+}

--- a/storage/kv/merkletreekv/padkv_test.go
+++ b/storage/kv/merkletreekv/padkv_test.go
@@ -1,0 +1,55 @@
+package merkletreekv
+
+import (
+	"testing"
+
+	"github.com/coniks-sys/coniks-go/crypto/sign"
+	"github.com/coniks-sys/coniks-go/crypto/vrf"
+	"github.com/coniks-sys/coniks-go/merkletree"
+	"github.com/coniks-sys/coniks-go/storage/kv"
+	"github.com/coniks-sys/coniks-go/utils"
+)
+
+func TestPADStoreLoad(t *testing.T) {
+	utils.WithDB(func(db kv.DB) {
+		key1 := "key"
+		val1 := []byte("value")
+
+		key2 := "key2"
+		val2 := []byte("value2")
+
+		key3 := "key3"
+		val3 := []byte("value3")
+		vrfPrivKey1, _ := vrf.GenerateKey(nil)
+		signKey, _ := sign.GenerateKey(nil)
+
+		pad, err := merkletree.NewPAD(&merkletree.MockAd{""}, signKey, vrfPrivKey1, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := pad.Set(key1, val1); err != nil {
+			t.Fatal(err)
+		}
+		if err := pad.Set(key2, val2); err != nil {
+			t.Fatal(err)
+		}
+		if err := pad.Set(key3, val3); err != nil {
+			t.Fatal(err)
+		}
+		pad.Update(nil)
+
+		if err := StorePAD(db, pad); err != nil {
+			t.Fatal(err)
+		}
+
+		padGot, err := LoadPAD(db, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		ap, err := padGot.Lookup(key1)
+		if ap.Leaf.Value == nil {
+			t.Fatalf("Cannot find key: %v", key1)
+		}
+		padGot.Update(nil) // just to make sure everything is okay
+	})
+}

--- a/storage/kv/merkletreekv/strkv.go
+++ b/storage/kv/merkletreekv/strkv.go
@@ -1,0 +1,40 @@
+package merkletreekv
+
+import (
+	"bytes"
+
+	"github.com/coniks-sys/coniks-go/merkletree"
+	"github.com/coniks-sys/coniks-go/storage/kv"
+	"github.com/coniks-sys/coniks-go/utils"
+)
+
+// StoreSTR stores str into the db under the key
+// which is the combination of the STRIdentifier
+// and the str's Epoch.
+func StoreSTR(db kv.DB, str *merkletree.SignedTreeRoot) error {
+	wb := db.NewBatch()
+	buff := new(bytes.Buffer)
+	if err := merkletree.EncodeSTR(buff, str); err != nil {
+		return err
+	}
+
+	wb.Put(strKey(str.Epoch), buff.Bytes())
+	return db.Write(wb)
+}
+
+// LoadSTR loads the STR corresponding to the specified epoch.
+func LoadSTR(db kv.DB, epoch uint64) (*merkletree.SignedTreeRoot, error) {
+	bbuff, err := db.Get(strKey(epoch))
+	if err != nil {
+		return nil, err
+	}
+	buff := bytes.NewBuffer(bbuff)
+	return merkletree.DecodeSTR(buff)
+}
+
+func strKey(epoch uint64) []byte {
+	key := make([]byte, 0, 1+8)
+	key = append(key, STRIdentifier)
+	key = append(key, utils.ULongToBytes(epoch)...)
+	return key
+}

--- a/storage/kv/merkletreekv/strkv_test.go
+++ b/storage/kv/merkletreekv/strkv_test.go
@@ -1,0 +1,81 @@
+package merkletreekv
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/coniks-sys/coniks-go/crypto/sign"
+	"github.com/coniks-sys/coniks-go/crypto/vrf"
+	"github.com/coniks-sys/coniks-go/merkletree"
+	"github.com/coniks-sys/coniks-go/storage/kv"
+	"github.com/coniks-sys/coniks-go/utils"
+)
+
+func TestSTRStore(t *testing.T) {
+	utils.WithDB(func(db kv.DB) {
+		key1 := "key"
+		val1 := []byte("value")
+
+		key2 := "key2"
+		val2 := []byte("value2")
+
+		vrfPrivKey1, _ := vrf.GenerateKey(nil)
+		signKey, _ := sign.GenerateKey(nil)
+
+		pad, err := merkletree.NewPAD(&merkletree.MockAd{""}, signKey, vrfPrivKey1, 10)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := pad.Set(key1, val1); err != nil {
+			t.Fatal(err)
+		}
+		pad.Update(nil)
+		str1 := pad.LatestSTR()
+		if err := StoreSTR(db, str1); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := pad.Set(key2, val2); err != nil {
+			t.Fatal(err)
+		}
+		pad.Update(nil)
+		str2 := pad.LatestSTR()
+		if err := StoreSTR(db, str2); err != nil {
+			t.Fatal(err)
+		}
+
+		// test loading STR from db
+		strGot1, err := LoadSTR(db, 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		strGot2, err := LoadSTR(db, 2)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(str1.Signature, strGot1.Signature) ||
+			!bytes.Equal(str1.PreviousSTRHash, strGot1.PreviousSTRHash) ||
+			str1.PreviousEpoch != strGot1.PreviousEpoch ||
+			str1.Epoch != strGot1.Epoch {
+			t.Fatal("Bad STR loading/storing",
+				"expect", str1,
+				"got", strGot1)
+		}
+
+		if !bytes.Equal(str2.Signature, strGot2.Signature) ||
+			!bytes.Equal(str2.PreviousSTRHash, strGot2.PreviousSTRHash) ||
+			str2.PreviousEpoch != strGot2.PreviousEpoch ||
+			str2.Epoch != strGot2.Epoch {
+			t.Fatal("Bad STR loading/storing",
+				"expect", str2,
+				"got", strGot2)
+		}
+
+		// test get non-exist str from db
+		if _, err = LoadSTR(db, 3); err != db.ErrNotFound() {
+			t.Fatal("Got unexpected STR from db")
+		}
+
+		// test key lookup from old STRs - see tests in kv/directorykv
+	})
+}


### PR DESCRIPTION
I have made an improvement in commit 84fc324bc27fee50c0619a9538c0d91421b804d1. This implementation's performance is better than #37 now. 

**Update** (description below)

This pull uses `encoding/gob` to encode/decode the merkletree structs to/from a buffer, and it implements the db backend hook for the merkletree package.

The package `merkletree` is now exporting some functions for encoding/decoding the PAD, STR, Merkletree and Policies from a buffer (any types that implement the `io.Writer` and `io.Reader` interface). This way, I think we can hide the detail implementations of the encoding/decoding from the developers.

Move to the hook implementation, there are two cases when we want to use a persistent storage:
- Store the current directory (pad). 
- Store the old STRs.

This hook exports APIs for store/load the PAD, STR to/from the db. 
