### PR TITLE
cgoVerify should return errors of the response and the verification

### DIFF
--- a/client/cgo/cgotest.go
+++ b/client/cgo/cgotest.go
@@ -1,19 +1,27 @@
 package main
 
 /*
-int testVerify(int type,
-	char *uname, int unameSize,
-	unsigned char *key, int keySize,
-	unsigned long long currentEpoch,
-	unsigned char *savedSTR, int strSize,
-	unsigned char *pk, int pkSize,
-	char *response, int responseSize) {
-	return cgoVerify(type,
-		uname, unameSize,
-		key, keySize,
-		currentEpoch,
-		savedSTR, strSize,
-		pk, pkSize, response, responseSize);
+struct cgoVerify_return {
+    int r0;
+    int r1;
+};
+extern struct cgoVerify_return cgoVerify(int p0, char* p1, int p2, void* p3,
+    int p4, long long unsigned int p5, void* p6, int p7, void* p8, int p9,
+    char* p10, int p11);
+
+struct cgoVerify_return testVerify(int type,
+    char *uname, int unameSize,
+    unsigned char *key, int keySize,
+    long long unsigned int currentEpoch,
+    unsigned char *savedSTR, int strSize,
+    unsigned char *pk, int pkSize,
+    char *response, int responseSize) {
+    return cgoVerify(type,
+        uname, unameSize,
+        key, keySize,
+        currentEpoch,
+        savedSTR, strSize,
+        pk, pkSize, response, responseSize);
 }
 
 #cgo CFLAGS: -Wno-implicit-function-declaration
@@ -49,15 +57,18 @@ func testVerify(t *testing.T) {
 		t.Fatal(err)
 	}
 	savedSTR := d.LatestSTR().Signature
-
-	if v := C.testVerify(protocol.RegistrationType,
+	v := C.testVerify(protocol.RegistrationType,
 		byteSliceToCcharPtr([]byte(uname)), C.int(len(uname)),
 		byteSliceToCucharPtr([]byte(key)), C.int(len(key)),
 		0,
 		byteSliceToCucharPtr(savedSTR), C.int(len(savedSTR)),
 		byteSliceToCucharPtr(pk), C.int(len(pk)),
-		byteSliceToCcharPtr(response), C.int(len(response))); v != C.int(protocol.Passed) {
-		t.Error(protocol.ErrorCode(v).Error())
+		byteSliceToCcharPtr(response), C.int(len(response)))
+
+	r0 := C.struct_cgoVerify_return(v).r0
+	r1 := C.struct_cgoVerify_return(v).r1
+	if r0 != C.int(protocol.Success) || r1 != C.int(protocol.Passed) {
+		t.Errorf("%s, %s\n", protocol.ErrorCode(r0).Error(), protocol.ErrorCode(r1).Error())
 	}
 	savedSTR = res.DirectoryResponse.(*protocol.DirectoryProof).STR.Signature
 
@@ -67,14 +78,18 @@ func testVerify(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if v := C.testVerify(protocol.KeyLookupType,
+
+	v = C.testVerify(protocol.KeyLookupType,
 		byteSliceToCcharPtr([]byte(uname)), C.int(len(uname)),
 		byteSliceToCucharPtr([]byte(key)), C.int(len(key)),
 		0,
 		byteSliceToCucharPtr(savedSTR), C.int(len(savedSTR)),
 		byteSliceToCucharPtr(pk), C.int(len(pk)),
-		byteSliceToCcharPtr(response), C.int(len(response))); v != C.int(protocol.Passed) {
-		t.Error(protocol.ErrorCode(v).Error())
+		byteSliceToCcharPtr(response), C.int(len(response)))
+	r0 = C.struct_cgoVerify_return(v).r0
+	r1 = C.struct_cgoVerify_return(v).r1
+	if r0 != C.int(protocol.Success) || r1 != C.int(protocol.Passed) {
+		t.Errorf("%s, %s\n", protocol.ErrorCode(r0).Error(), protocol.ErrorCode(r1).Error())
 	}
 
 	res, _ = d.KeyLookup(&protocol.KeyLookupRequest{"bob"})
@@ -82,13 +97,16 @@ func testVerify(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if v := C.testVerify(protocol.KeyLookupType,
+	v = C.testVerify(protocol.KeyLookupType,
 		byteSliceToCcharPtr([]byte(uname)), C.int(len(uname)),
 		byteSliceToCucharPtr([]byte(key)), C.int(len(key)),
 		0,
 		byteSliceToCucharPtr(savedSTR), C.int(len(savedSTR)),
 		byteSliceToCucharPtr(pk), C.int(len(pk)),
-		byteSliceToCcharPtr(response), C.int(len(response))); v != C.int(protocol.ErrorNameNotFound) {
-		t.Error(protocol.ErrorCode(v).Error())
+		byteSliceToCcharPtr(response), C.int(len(response)))
+	r0 = C.struct_cgoVerify_return(v).r0
+	r1 = C.struct_cgoVerify_return(v).r1
+	if r0 != C.int(protocol.ErrorNameNotFound) || r1 != C.int(protocol.Passed) {
+		t.Errorf("%s, %s\n", protocol.ErrorCode(r0).Error(), protocol.ErrorCode(r1).Error())
 	}
 }

--- a/protocol/error.go
+++ b/protocol/error.go
@@ -25,6 +25,7 @@ const (
 	ErrorBadSTR
 	ErrorBadCommitment
 	ErrorBadBinding
+	ErrorCouldNotVerify
 )
 
 // ErrorResponses contains error codes that
@@ -51,6 +52,7 @@ var (
 		ErrorBadSTR:                    errors.New("[coniks] The hash chain is inconsistent"),
 		ErrorBadCommitment:             errors.New("[coniks] Bad commitment"),
 		ErrorBadBinding:                errors.New("[coniks] Bad name-to-key binding"),
+		ErrorCouldNotVerify:            errors.New("[coniks] Could not verify"),
 	}
 )
 


### PR DESCRIPTION
We're going to want to verify some returned data, even when the response wasn't a success.