### PR TITLE
TemporaryBinding should include the issued epoch for verifications

### DIFF
--- a/merkletree/pad.go
+++ b/merkletree/pad.go
@@ -123,7 +123,7 @@ func (pad *PAD) LatestSTR() *SignedTreeRoot {
 
 func (pad *PAD) TB(name string, value []byte) (*TemporaryBinding, error) {
 	index, _ := pad.computePrivateIndex(name, pad.policies.vrfPrivateKey)
-	tb := NewTB(pad.signKey, pad.latestSTR.Signature, index, value)
+	tb := NewTB(pad.signKey, pad.latestSTR.Epoch+1, pad.latestSTR.Signature, index, value)
 	err := pad.tree.Set(index, name, value)
 	return tb, err
 }

--- a/merkletree/tb.go
+++ b/merkletree/tb.go
@@ -1,17 +1,26 @@
 package merkletree
 
-import "github.com/coniks-sys/coniks-go/crypto/sign"
+import (
+	"bytes"
+
+	"github.com/coniks-sys/coniks-go/crypto/sign"
+)
 
 type TemporaryBinding struct {
-	Index     []byte
-	Value     []byte
-	Signature []byte
+	// IssuedEpoch would not be included in the serialization.
+	// To verify the validation of IssuedEpoch, we can compare it
+	// against the epoch of STR included in the serialization.
+	IssuedEpoch uint64
+	Index       []byte
+	Value       []byte
+	Signature   []byte
 }
 
-func NewTB(key sign.PrivateKey, strSig, index, value []byte) *TemporaryBinding {
+func NewTB(key sign.PrivateKey, ep uint64, strSig, index, value []byte) *TemporaryBinding {
 	tb := &TemporaryBinding{
-		Index: index,
-		Value: value,
+		IssuedEpoch: ep,
+		Index:       index,
+		Value:       value,
 	}
 	tbPreSig := tb.Serialize(strSig)
 	tb.Signature = key.Sign(tbPreSig)
@@ -24,4 +33,13 @@ func (tb *TemporaryBinding) Serialize(strSig []byte) []byte {
 	tbBytes = append(tbBytes, tb.Index...)
 	tbBytes = append(tbBytes, tb.Value...)
 	return tbBytes
+}
+
+func (tb *TemporaryBinding) Verify(ap *AuthenticationPath) bool {
+	// compare TB's index with authentication path's index (after Update)
+	if !bytes.Equal(ap.LookupIndex, tb.Index) ||
+		!bytes.Equal(ap.Leaf.Value, tb.Value) {
+		return false
+	}
+	return true
 }


### PR DESCRIPTION
After receiving a TB from the key server, the client needs to verify this TB at the next epoch. It could do this by compare the current saved STR with the STR included in the TB's signature, ~~which means the client needs to verify the TB's signature again. This could cause some overhead for the client.~~ (this is wrong). Thus, we add an extra field `IssuedEpoch` in the TB, but the key server isn't bound to `IssuedEpoch` by its signature. However, this field would be verified by the client when it receives the TB, using its saved STR, to prevent the tampering from the server.