### PR TITLE
Merkletree pkg documentation

### DIFF
--- a/merkletree/doc.go
+++ b/merkletree/doc.go
@@ -6,7 +6,17 @@ to help other developers use it in their implementation easily.
 
 Persistent Authenticated Dictionary
 
-This module implements a persistent authenticated dictionary (PAD) data structure.
+This module implements a persistent authenticated dictionary (PAD) data structure,
+which supports dictionary operations with two additional features:
+(1) lookups return a cryptographic proof of correctness along with the result,
+and (2) it supports taking and storing snapshots of the current contents of
+the dictionary to allow lookups in historical versions of the dictionary.
+In CONIKS, the general PAD design is extended to return proofs for inserts.
+This design does not support deletions, and that individual snapshots are linked
+via a hash chain to commit the entire history. This PAD implementation also supports
+randomizing the order of directory entries by changing the VRF private key.
+This protects the user's privacy against other malicious parties who
+wish to obtain information about users by querying the key directory.
 
 Merkle Prefix Tree
 

--- a/merkletree/doc.go
+++ b/merkletree/doc.go
@@ -14,8 +14,8 @@ This module implements the Merkle prefix tree, which is the data structure
 underlying our PAD implementation. It is a binary tree, and that there are
 two types of leaf nodes: empty leaf node and user leaf node. Each node contains
 its prefix index and its level value. It provides methods to insert, update
-(to update an existing key-value pair) and lookup. The tree is append-only,
-and it does not support the deletion of values.
+(to update an existing key-value pair) and lookup.
+The tree has the property of not being able to remove user leafs.
 This Merkle prefix tree implementation also preserves the privacy feature:
 the prefix used to search in the tree is a cryptographic transformation (VRF)
 of the search key, and values are concealed using cryptographic commitments.

--- a/merkletree/doc.go
+++ b/merkletree/doc.go
@@ -1,0 +1,29 @@
+/*
+Package merkletree implements a Merkle prefix tree and related data structures.
+The Merkle prefix tree is one of the most important components of the CONIKS protocol.
+We implemented this data structure separately as a library
+to help other developers use it in their implementation easily.
+
+Persistent Authenticated Dictionary
+
+This module implements a persistent authenticated dictionary (PAD) where the client
+can query a name-to-key binding at a specific epoch and get authenticated answer.
+The PAD is represented by a hash chain committing to the entire history. This hash chain
+is used to prove to the client that the PAD is maintaining a linear hash chain
+and there is no equivocations.
+
+Merkle Tree
+
+This module implements the Merkle prefix tree data structure. It provides methods to
+insert, update and lookup. The tree is append-only which means there is no ways to delete
+any node from the tree or change a user leaf node to an empty node.
+All the tree hash operations use the hash algorithm provided by our crypto package
+(see https://godoc.org/github.com/coniks-sys/coniks-go/crypto).
+
+Temporary Binding
+
+This module implements a signed promise for registration operations. The main purpose of
+temporary binding is to allow immediate use of the key without having to wait for the next epoch.
+This will be split into a separate protocol extension in a future release.
+*/
+package merkletree

--- a/merkletree/doc.go
+++ b/merkletree/doc.go
@@ -21,11 +21,11 @@ wish to obtain information about users by querying the key directory.
 Merkle Prefix Tree
 
 This module implements the Merkle prefix tree, which is the data structure
-underlying our PAD implementation. It is a binary tree, and that there are
+underlying our PAD implementation. It is a binary tree with
 two types of leaf nodes: empty leaf node and user leaf node. Each node contains
 its prefix index and its level value. It provides methods to insert, update
 (to update an existing key-value pair) and lookup.
-The tree has the property of not being able to remove user leafs.
+The tree has the property of not being able to remove user leaves.
 This Merkle prefix tree implementation also preserves the privacy feature:
 the prefix used to search in the tree is a cryptographic transformation (VRF)
 of the search key, and values are concealed using cryptographic commitments.

--- a/merkletree/doc.go
+++ b/merkletree/doc.go
@@ -19,11 +19,5 @@ insert, update and lookup. The tree is append-only which means there is no ways 
 any node from the tree or change a user leaf node to an empty node.
 All the tree hash operations use the hash algorithm provided by our crypto package
 (see https://godoc.org/github.com/coniks-sys/coniks-go/crypto).
-
-Temporary Binding
-
-This module implements a signed promise for registration operations. The main purpose of
-temporary binding is to allow immediate use of the key without having to wait for the next epoch.
-This will be split into a separate protocol extension in a future release.
 */
 package merkletree

--- a/merkletree/doc.go
+++ b/merkletree/doc.go
@@ -6,18 +6,20 @@ to help other developers use it in their implementation easily.
 
 Persistent Authenticated Dictionary
 
-This module implements a persistent authenticated dictionary (PAD) where the client
-can query a name-to-key binding at a specific epoch and get authenticated answer.
-The PAD is represented by a hash chain committing to the entire history. This hash chain
-is used to prove to the client that the PAD is maintaining a linear hash chain
-and there is no equivocations.
+This module implements a persistent authenticated dictionary (PAD) data structure.
 
-Merkle Tree
+Merkle Prefix Tree
 
-This module implements the Merkle prefix tree data structure. It provides methods to
-insert, update and lookup. The tree is append-only which means there is no ways to delete
-any node from the tree or change a user leaf node to an empty node.
-All the tree hash operations use the hash algorithm provided by our crypto package
+This module implements the Merkle prefix tree, which is the data structure
+underlying our PAD implementation. It is a binary tree, and that there are
+two types of leaf nodes: empty leaf node and user leaf node. Each node contains
+its prefix index and its level value. It provides methods to insert, update
+(to update an existing key-value pair) and lookup. The tree is append-only,
+and it does not support the deletion of values.
+This Merkle prefix tree implementation also preserves the privacy feature:
+the prefix used to search in the tree is a cryptographic transformation (VRF)
+of the search key, and values are concealed using cryptographic commitments.
+The VRF, commitment scheme and hash operations are provided by our crypto package
 (see https://godoc.org/github.com/coniks-sys/coniks-go/crypto).
 */
 package merkletree

--- a/merkletree/merkletree.go
+++ b/merkletree/merkletree.go
@@ -117,8 +117,8 @@ func (m *MerkleTree) Get(lookupIndex []byte) *AuthenticationPath {
 
 // Set inserts or updates the value of the given index
 // calculated from the key to the tree. It will generate a new commitment
-// for the leaf node. In case of updating, the leaf node's value and commitment
-// will be replaced with the new value and new generated commitment.
+// for the leaf node. In case of an update, the leaf node's value and commitment
+// will be replaced with the new value and newly generated commitment.
 func (m *MerkleTree) Set(index []byte, key string, value []byte) error {
 	commitment, err := crypto.NewCommit([]byte(key), value)
 	if err != nil {

--- a/merkletree/pad.go
+++ b/merkletree/pad.go
@@ -80,7 +80,7 @@ func (pad *PAD) updateInternal(policies *Policies, epoch uint64) {
 	}
 }
 
-// Update generates a new snapshot of the directory.
+// Update generates a new snapshot of the tree.
 // Specifically, it extends the hash chain by issuing
 // a new signed tree root. It may remove some older signed tree roots from
 // memory if the cached PAD snapshots exceeded the maximum capacity.
@@ -139,10 +139,13 @@ func (pad *PAD) LatestSTR() *SignedTreeRoot {
 	return pad.latestSTR
 }
 
+// Sign uses the _current_ signing key underlying the PAD to sign msg.
 func (pad *PAD) Sign(msg ...[]byte) []byte {
 	return pad.signKey.Sign(bytes.Join(msg, nil))
 }
 
+// Index uses the _current_ VRF private key of the PAD to compute
+// the private index of the requested key.
 func (pad *PAD) Index(key string) []byte {
 	index, _ := pad.computePrivateIndex(key, pad.policies.vrfPrivateKey)
 	return index

--- a/merkletree/pad.go
+++ b/merkletree/pad.go
@@ -81,10 +81,15 @@ func (pad *PAD) updateInternal(policies *Policies, epoch uint64) {
 }
 
 // Update generates a new snapshot of the tree.
+// It should be called in the beginning of each epoch.
 // Specifically, it extends the hash chain by issuing
 // a new signed tree root. It may remove some older signed tree roots from
 // memory if the cached PAD snapshots exceeded the maximum capacity.
-// The Policies pointer can be nil if the policies does not change.
+// policies could be nil if the PAD's policies do not change.
+// If the VRF private key is changed (by passing a new Policies),
+// the underlying tree would be reshuffled. It also means
+// the private index of all new key-to-value bindings
+// would be computed using the new VRF private key.
 func (pad *PAD) Update(policies *Policies) {
 	// delete older str(s) as needed
 	if len(pad.loadedEpochs) == cap(pad.loadedEpochs) {

--- a/merkletree/pad.go
+++ b/merkletree/pad.go
@@ -86,8 +86,8 @@ func (pad *PAD) updateInternal(policies *Policies, epoch uint64) {
 
 // Update generates a new snapshot of the directory.
 // Specifically, it extends the hash chain by issuing
-// new signed tree root. It may remove some older signed tree roots from
-// memory if the cached PAD snapshots exceeded its maximum capacity.
+// a new signed tree root. It may remove some older signed tree roots from
+// memory if the cached PAD snapshots exceeded the maximum capacity.
 // The Policies pointer can be nil if the policies does not change.
 func (pad *PAD) Update(policies *Policies) {
 	// delete older str(s) as needed
@@ -101,7 +101,7 @@ func (pad *PAD) Update(policies *Policies) {
 	pad.updateInternal(policies, pad.latestSTR.Epoch+1)
 }
 
-// Set computes the private index of the given name using
+// Set computes the private index of the given key using
 // the current VRF private key (which will be inserted in the next
 // signed tree root) to create a new index-to-key binding,
 // and then Set inserts it into the Merkle tree underlying the PAD.
@@ -114,7 +114,7 @@ func (pad *PAD) Lookup(name string) (*AuthenticationPath, error) {
 	return pad.LookupInEpoch(name, pad.latestSTR.Epoch)
 }
 
-// LookupInEpoch searches the requested name in the snapshot at requested epoch.
+// LookupInEpoch searches the requested name in the snapshot at the requested epoch.
 // It returns ErrorSTRNotFound if the signed tree root of the requested epoch
 // has been removed from memory.
 func (pad *PAD) LookupInEpoch(name string, epoch uint64) (*AuthenticationPath, error) {
@@ -129,7 +129,7 @@ func (pad *PAD) LookupInEpoch(name string, epoch uint64) (*AuthenticationPath, e
 }
 
 // GetSTR returns the signed tree root of the requested epoch.
-// This signed tree root is read from the caching snapshots of the PAD.
+// This signed tree root is read from the cached snapshots of the PAD.
 // It returns nil if the signed tree root has been removed from the memory.
 func (pad *PAD) GetSTR(epoch uint64) *SignedTreeRoot {
 	if epoch >= pad.latestSTR.Epoch {

--- a/merkletree/pad.go
+++ b/merkletree/pad.go
@@ -89,7 +89,7 @@ func (pad *PAD) updateInternal(policies *Policies, epoch uint64) {
 // If the VRF private key is changed (by passing a new Policies),
 // the underlying tree would be reshuffled. It also means
 // the private index of all new key-to-value bindings
-// would be computed using the new VRF private key.
+// will be computed using the new VRF private key.
 func (pad *PAD) Update(policies *Policies) {
 	// delete older str(s) as needed
 	if len(pad.loadedEpochs) == cap(pad.loadedEpochs) {

--- a/merkletree/policy.go
+++ b/merkletree/policy.go
@@ -8,6 +8,11 @@ import (
 
 type Timestamp uint64
 
+// Policies is a summary of the directory's
+// current security policies. This includes the public part
+// of the VRF key used to generate private indices,
+// the cryptographic algorithms in use, as well as
+// the protocol version number.
 type Policies struct {
 	LibVersion    string
 	HashID        string
@@ -30,8 +35,10 @@ func NewPolicies(epDeadline Timestamp, vrfPrivKey vrf.PrivateKey) *Policies {
 	}
 }
 
-// Serialize encodes the policy to a byte array with the following format:
-// [lib version, cryptographic algorithm in use, epoch deadline, vrf public key]
+// Serialize serializes the policies for signing the tree root.
+// Default policies serialization includes the library version (see version.go),
+// the cryptographic algorithms in use (i.e., the hashing algorithm),
+// the epoch deadline and the public part of the VRF key.
 func (p *Policies) Serialize() []byte {
 	var bs []byte
 	bs = append(bs, []byte(p.LibVersion)...)                       // lib Version

--- a/merkletree/proof.go
+++ b/merkletree/proof.go
@@ -10,7 +10,7 @@ import (
 // ProofNode can be a leaf node or an empty node,
 // which is included in the returned AuthenticationPath
 // of a given index. The type of that node can be determined
-// by IsEmpty value. It also provides an opening of
+// by the IsEmpty value. It also provides an opening of
 // the commitment if the returned AuthenticationPath
 // is a proof of inclusion.
 type ProofNode struct {
@@ -90,7 +90,9 @@ func (ap *AuthenticationPath) verifyBinding(key, value []byte) bool {
 }
 
 // Verify recomputes the tree's root node from the authentication path,
-// and compares it to the tree hash in the corresponding signed tree root.
+// and compares it to treeHash, which is taken from a STR.
+// Specifically, treeHash has to come from the STR whose tree returns
+// the authentication path.
 // This should be called after the VRF index is verified successfully.
 func (ap *AuthenticationPath) Verify(key, value, treeHash []byte) bool {
 	if ap.ProofType() == ProofOfAbsence { // proof of absence

--- a/merkletree/proof.go
+++ b/merkletree/proof.go
@@ -7,7 +7,7 @@ import (
 	"github.com/coniks-sys/coniks-go/utils"
 )
 
-// ProofNode can be a leaf node or an empty node,
+// ProofNode can be a user node or an empty node,
 // which is included in the returned AuthenticationPath
 // of a given index. The type of that node can be determined
 // by the IsEmpty value. It also provides an opening of
@@ -54,12 +54,8 @@ const (
 // the prefix path between the corresponding leaf node
 // (of type ProofNode) and the root. This is a proof
 // of inclusion or absence of requested index.
-// The proof type can be determined by
-//  if !bytes.Equal(ap.Leaf.Index, ap.LookupIndex) {
-//	 // Proof of absence
-//	} else {
-//	 // Proof of inclusion
-//  }
+// A proof of inclusion is when the leaf index
+// equals the lookup index.
 type AuthenticationPath struct {
 	TreeNonce   []byte
 	PrunedTree  [][crypto.HashSizeByte]byte

--- a/merkletree/str.go
+++ b/merkletree/str.go
@@ -8,12 +8,13 @@ import (
 	"github.com/coniks-sys/coniks-go/utils"
 )
 
-// SignedTreeRoot represents a signed tree root, which is generated
+// SignedTreeRoot represents a signed tree root (STR), which is generated
 // at the beginning of every epoch.
 // Signed tree roots contain the current root node,
 // the current and previous epochs, the hash of the
 // previous STR, and its signature.
-// STR should be final
+// The epoch number is a counter from 0, and increases by 1
+// when a new signed tree root is issued by the PAD.
 type SignedTreeRoot struct {
 	tree            *MerkleTree
 	TreeHash        []byte
@@ -42,8 +43,8 @@ func NewSTR(key sign.PrivateKey, policies Policies, m *MerkleTree, epoch uint64,
 	return str
 }
 
-// Serialize encodes the STR to a byte array with the following format:
-// [epoch, previous epoch, tree hash, previous STR hash, policies serialization]
+// Serialize serializes the signed tree root into
+// the correct format for signing.
 func (str *SignedTreeRoot) Serialize() []byte {
 	var strBytes []byte
 	strBytes = append(strBytes, util.ULongToBytes(str.Epoch)...) // t - epoch number
@@ -56,6 +57,10 @@ func (str *SignedTreeRoot) Serialize() []byte {
 	return strBytes
 }
 
+// VerifyHashChain computes the hash of savedSTR's signature,
+// and compares it to the hash of previous STR included
+// in the issued STR. The hash chain is valid if
+// these two hash values are equal.
 func (str *SignedTreeRoot) VerifyHashChain(savedSTR *SignedTreeRoot) bool {
 	hash := crypto.Digest(savedSTR.Signature)
 	return str.Epoch == savedSTR.Epoch+1 && bytes.Equal(hash, str.PreviousSTRHash)

--- a/merkletree/str.go
+++ b/merkletree/str.go
@@ -44,7 +44,7 @@ func NewSTR(key sign.PrivateKey, policies Policies, m *MerkleTree, epoch uint64,
 }
 
 // Serialize serializes the signed tree root into
-// the correct format for signing.
+// a specified format for signing.
 func (str *SignedTreeRoot) Serialize() []byte {
 	var strBytes []byte
 	strBytes = append(strBytes, util.ULongToBytes(str.Epoch)...) // t - epoch number

--- a/merkletree/version.go
+++ b/merkletree/version.go
@@ -1,7 +1,6 @@
 package merkletree
 
 const (
-	// Version indicates the current version of the library.
-	// This is matched with our release version on Github.
+	// Version indicates the current protocol version.
 	Version = "0.1.0"
 )

--- a/merkletree/version.go
+++ b/merkletree/version.go
@@ -1,5 +1,7 @@
 package merkletree
 
 const (
-	Version = "0.1"
+	// Version indicates the current version of the library.
+	// This is matched with our release version on Github.
+	Version = "0.1.0"
 )

--- a/merkletree/version.go
+++ b/merkletree/version.go
@@ -2,5 +2,5 @@ package merkletree
 
 const (
 	// Version indicates the current protocol version.
-	Version = "0.1.0"
+	Version = "3.0"
 )


### PR DESCRIPTION
Part of #32 
- Unexport functions and types that are not being used outside the package
- Add comments for exporting functions
