### PR TITLE
Quickfix: Ensure start epoch of LookupInEpochRequest and MonitoringRequest is in PAD

### DIFF
--- a/protocol/directory.go
+++ b/protocol/directory.go
@@ -69,13 +69,16 @@ func (d *ConiksDirectory) HandleOps(req *Request) (*Response, ErrorCode) {
 		}
 	case KeyLookupInEpochType:
 		if msg, ok := req.Request.(*KeyLookupInEpochRequest); ok {
-			if len(msg.Username) > 0 {
+			if len(msg.Username) > 0 &&
+				msg.Epoch <= d.LatestSTR().Epoch {
 				return d.KeyLookupInEpoch(msg)
 			}
 		}
 	case MonitoringType:
 		if msg, ok := req.Request.(*MonitoringRequest); ok {
-			if len(msg.Username) > 0 && msg.StartEpoch <= msg.EndEpoch {
+			if len(msg.Username) > 0 &&
+				msg.StartEpoch <= d.LatestSTR().Epoch &&
+				msg.StartEpoch <= msg.EndEpoch {
 				return d.Monitor(msg)
 			}
 		}

--- a/protocol/directory_test.go
+++ b/protocol/directory_test.go
@@ -325,7 +325,7 @@ func TestMonitoringBadStartEpoch(t *testing.T) {
 		t.Fatal("Expect error", ErrorMalformedClientMessage, "got", err)
 	}
 
-	// Send an invalid MonitoringRequest (startEpoch < EndEpoch)
+	// Send an invalid MonitoringRequest (startEpoch > EndEpoch)
 	// Expect ErrorMalformedClientMessage
 	req = &Request{
 		Type:    MonitoringType,

--- a/protocol/directory_test.go
+++ b/protocol/directory_test.go
@@ -285,15 +285,53 @@ func TestDirectoryKeyLookupInEpoch(t *testing.T) {
 	}
 }
 
-func TestHandleOps(t *testing.T) {
+func TestDirectoryKeyLookupInEpochBadEpoch(t *testing.T) {
+	N := 3
+
 	d, _ := NewTestDirectory(t, false)
-	// Send an invalid KeyLookupInEpochRequest
+	for i := 0; i < N; i++ {
+		d.Update()
+	}
+
+	// Send an invalid KeyLookupInEpochRequest (epoch > d.LatestEpoch())
+	// Expect ErrorMalformedClientMessage
+	req := &Request{
+		Type:    KeyLookupInEpochType,
+		Request: &KeyLookupInEpochRequest{"alice", uint64(6)},
+	}
+
+	_, err := d.HandleOps(req)
+	if err != ErrorMalformedClientMessage {
+		t.Fatal("Expect error", ErrorMalformedClientMessage, "got", err)
+	}
+}
+
+func TestMonitoringBadStartEpoch(t *testing.T) {
+	N := 3
+
+	d, _ := NewTestDirectory(t, false)
+	for i := 0; i < N; i++ {
+		d.Update()
+	}
+
+	// Send an invalid MonitoringRequest (startEpoch > d.LatestEpoch())
 	// Expect ErrorMalformedClientMessage
 	req := &Request{
 		Type:    MonitoringType,
-		Request: &MonitoringRequest{"alice", uint64(2), uint64(0)},
+		Request: &MonitoringRequest{"alice", uint64(6), uint64(10)},
 	}
 	_, err := d.HandleOps(req)
+	if err != ErrorMalformedClientMessage {
+		t.Fatal("Expect error", ErrorMalformedClientMessage, "got", err)
+	}
+
+	// Send an invalid MonitoringRequest (startEpoch < EndEpoch)
+	// Expect ErrorMalformedClientMessage
+	req = &Request{
+		Type:    MonitoringType,
+		Request: &MonitoringRequest{"alice", uint64(2), uint64(0)},
+	}
+	_, err = d.HandleOps(req)
 	if err != ErrorMalformedClientMessage {
 		t.Fatal("Expect error", ErrorMalformedClientMessage, "got", err)
 	}


### PR DESCRIPTION
Otherwise directory.LookupInEpoch() fails with ErrorDirectory, though a start epoch that is > the latest epoch indicates a malformed client message.