### PR TITLE
Fix bug: Registration collision in the same epoch when the keyserver doesn't use TBs

### DIFF
--- a/keyserver/listener.go
+++ b/keyserver/listener.go
@@ -76,7 +76,7 @@ func (server *ConiksServer) acceptClient(conn net.Conn, handler func(msg []byte)
 func malformedClientMsg(err error) ([]byte, error) {
 	// check if we're just propagating a message
 	if err == nil {
-		err = ErrorMalformedClientMessage.Error()
+		err = ErrorMalformedClientMessage
 	}
 	response := NewErrorResponse(ErrorMalformedClientMessage)
 	res, e := MarshalResponse(response)
@@ -95,7 +95,7 @@ func (server *ConiksServer) makeHandler(acceptableTypes map[int]bool) func(msg [
 		}
 		if !acceptableTypes[req.Type] {
 			log.Printf("unacceptable message type: %q", req.Type)
-			return malformedClientMsg(ErrorMalformedClientMessage.Error())
+			return malformedClientMsg(ErrorMalformedClientMessage)
 		}
 
 		switch req.Type {
@@ -116,6 +116,6 @@ func (server *ConiksServer) makeHandler(acceptableTypes map[int]bool) func(msg [
 		if err != nil {
 			panic(err)
 		}
-		return res, e.Error()
+		return res, e
 	}
 }

--- a/merkletree/pad_test.go
+++ b/merkletree/pad_test.go
@@ -86,7 +86,7 @@ func TestPADHashChain(t *testing.T) {
 	}
 
 	// lookup
-	ap, _ := pad.Lookup(key1)
+	ap, _ := pad.LookupInLatestEpoch(key1)
 	if ap.Leaf.Value == nil {
 		t.Error("Cannot find key:", key1)
 		return
@@ -95,7 +95,7 @@ func TestPADHashChain(t *testing.T) {
 		t.Error(key1, "value mismatch")
 	}
 
-	ap, _ = pad.Lookup(key2)
+	ap, _ = pad.LookupInLatestEpoch(key2)
 	if ap.Leaf.Value == nil {
 		t.Error("Cannot find key:", key2)
 		return
@@ -104,7 +104,7 @@ func TestPADHashChain(t *testing.T) {
 		t.Error(key2, "value mismatch")
 	}
 
-	ap, _ = pad.Lookup(key3)
+	ap, _ = pad.LookupInLatestEpoch(key3)
 	if ap.Leaf.Value == nil {
 		t.Error("Cannot find key:", key3)
 		return
@@ -205,7 +205,7 @@ func TestPoliciesChange(t *testing.T) {
 	}
 	pad.Update(nil)
 
-	ap, _ := pad.Lookup(key1)
+	ap, _ := pad.LookupInLatestEpoch(key1)
 	if ap.Leaf.Value == nil {
 		t.Error("Cannot find key:", key1)
 	}
@@ -213,7 +213,7 @@ func TestPoliciesChange(t *testing.T) {
 		t.Error(key1, "value mismatch")
 	}
 
-	ap, _ = pad.Lookup(key2)
+	ap, _ = pad.LookupInLatestEpoch(key2)
 	if ap.Leaf.Value == nil {
 		t.Error("Cannot find key:", key2)
 	}
@@ -365,7 +365,7 @@ func benchPADLookup(b *testing.B, entries uint64) {
 			key = keyPrefix + string(n%int(entries))
 		}
 		b.StartTimer()
-		_, err := pad.Lookup(key)
+		_, err := pad.LookupInLatestEpoch(key)
 		if err != nil {
 			b.Fatalf("Coudldn't lookup key=%s", key)
 		}

--- a/merkletree/tb_test.go
+++ b/merkletree/tb_test.go
@@ -34,7 +34,7 @@ func TestTB(t *testing.T) {
 	// create next epoch and see if the TB is inserted as promised:
 	pad.Update(nil)
 
-	ap, err := pad.Lookup(key)
+	ap, err := pad.LookupInLatestEpoch(key)
 	// compare TB's index with authentication path's index (after Update):
 	if !bytes.Equal(ap.LookupIndex, tb.Index) ||
 		!bytes.Equal(ap.Leaf.Value, tb.Value) {

--- a/protocol/directory_test.go
+++ b/protocol/directory_test.go
@@ -106,6 +106,15 @@ func TestRegisterExistedUserWithoutTB(t *testing.T) {
 		t.Fatal("Unable to register")
 	}
 
+	// re-register in the same epoch
+	// expect ErrorNameExisted
+	_, err = d.Register(&RegistrationRequest{
+		Username: "alice",
+		Key:      []byte("key2")})
+	if err != ErrorNameExisted {
+		t.Error("Unexpected error", "got", err, "want", ErrorNameExisted)
+	}
+
 	d.Update()
 	// expect return a proof of inclusion
 	// and error ErrorNameExisted
@@ -119,6 +128,11 @@ func TestRegisterExistedUserWithoutTB(t *testing.T) {
 	if ap := df.AP; ap == nil || !bytes.Equal(ap.LookupIndex, ap.Leaf.Index) {
 		t.Fatal("Expect a proof of inclusion")
 	}
+
+	if ap := df.AP; !bytes.Equal(ap.Leaf.Value, []byte("key")) {
+		t.Fatal("Unexpected key change")
+	}
+
 	if df.TB != nil {
 		t.Fatal("Expect returned TB is nil")
 	}

--- a/protocol/error.go
+++ b/protocol/error.go
@@ -3,8 +3,6 @@
 
 package protocol
 
-import "errors"
-
 type ErrorCode int
 
 const (
@@ -21,7 +19,7 @@ const (
 	ErrorBadSignature
 	ErrorBadVRFProof
 	ErrorBadIndex
-	ErrorBadMapping
+	ErrorBadAuthPath
 	ErrorBadSTR
 	ErrorBadCommitment
 	ErrorBadBinding
@@ -36,26 +34,26 @@ var ErrorResponses = map[ErrorCode]bool{
 }
 
 var (
-	errorMessages = map[ErrorCode]error{
-		Success:                     nil,
-		ErrorMalformedClientMessage: errors.New("[coniks] Malformed client request"),
-		ErrorNameExisted:            errors.New("[coniks] Registering identity is already registered"),
-		ErrorNameNotFound:           errors.New("[coniks] Name not found"),
-		ErrorDirectory:              errors.New("[coniks] Directory error"),
+	errorMessages = map[ErrorCode]string{
+		Success:                     "[coniks] Successful client request",
+		ErrorMalformedClientMessage: "[coniks] Malformed client message",
+		ErrorNameExisted:            "[coniks] Registering identity is already registered",
+		ErrorNameNotFound:           "[coniks] Searched name not found in directory",
+		ErrorDirectory:              "[coniks] Directory error",
 
-		Passed: nil,
-		ErrorMalformedDirectoryMessage: errors.New("[coniks] Malformed directory message"),
-		ErrorBadSignature:              errors.New("[coniks] Directory's signature is invalid"),
-		ErrorBadVRFProof:               errors.New("[coniks] Bad VRF proof"),
-		ErrorBadIndex:                  errors.New("[coniks] Directory returned a bad index"),
-		ErrorBadMapping:                errors.New("[coniks] Returned name-to-key mapping is inconsistent with the root hash"),
-		ErrorBadSTR:                    errors.New("[coniks] The hash chain is inconsistent"),
-		ErrorBadCommitment:             errors.New("[coniks] Bad commitment"),
-		ErrorBadBinding:                errors.New("[coniks] Bad name-to-key binding"),
-		ErrorCouldNotVerify:            errors.New("[coniks] Could not verify"),
+		Passed: "[coniks] Consistency checks passed",
+		ErrorMalformedDirectoryMessage: "[coniks] Malformed directory message",
+		ErrorBadSignature:              "[coniks] Directory's signature on STR or TB is invalid",
+		ErrorBadVRFProof:               "[coniks] Returned index is not valid for the given name",
+		ErrorBadIndex:                  "[coniks] The index in the TB and the index in the auth path do not match",
+		ErrorBadAuthPath:               "[coniks] Returned binding is inconsistent with the tree root hash",
+		ErrorBadSTR:                    "[coniks] The hash chain is inconsistent",
+		ErrorBadCommitment:             "[coniks] The binding commitment is invalid",
+		ErrorBadBinding:                "[coniks] Key in the binding is inconsistent",
+		ErrorCouldNotVerify:            "[coniks] Could not verify",
 	}
 )
 
-func (e ErrorCode) Error() error {
+func (e ErrorCode) Error() string {
 	return errorMessages[e]
 }


### PR DESCRIPTION
- Add `LookupInCurrentEpoch` to lookup in the current tree 
- Rename `Lookup` to `LookupInLatestEpoch`
- See directory_test.go (TestRegisterExistedUserWithoutTB) for demostration scenario.

