### PR TITLE
Make the usage of the registration bot configurable

### DIFF
--- a/keyserver/coniksserver/cmd/init.go
+++ b/keyserver/coniksserver/cmd/init.go
@@ -43,15 +43,21 @@ func init() {
 
 func mkConfig(dir string) {
 	file := path.Join(dir, "config.toml")
+	addrs := []*keyserver.Address{
+		&keyserver.Address{
+			Address:           "unix:///tmp/coniks.sock",
+			AllowRegistration: true,
+		},
+		&keyserver.Address{
+			Address:     "tcp://0.0.0.0:3000",
+			TLSCertPath: "server.pem",
+			TLSKeyPath:  "server.key",
+		},
+	}
 	var conf = keyserver.ServerConfig{
 		DatabasePath:        "coniks.db",
 		LoadedHistoryLength: 1000000,
-		TLS: &keyserver.TLSConnection{
-			LocalAddress:  "/tmp/coniks.sock",
-			PublicAddress: "0.0.0.0:3000",
-			TLSCertPath:   "server.pem",
-			TLSKeyPath:    "server.key",
-		},
+		Addresses:           addrs,
 		Policies: &keyserver.ServerPolicies{
 			EpochDeadline: 60,
 			VRFKeyPath:    "vrf.priv",

--- a/keyserver/coniksserver/cmd/run.go
+++ b/keyserver/coniksserver/cmd/run.go
@@ -18,7 +18,7 @@ var runCmd = &cobra.Command{
 	Short: "Run a CONIKS server instance",
 	Long: `Run a CONIKS server instance
 
-This will look for config files with default names (config.toml) 
+This will look for config files with default names (config.toml)
 in the current directory if not specified differently.
 	`,
 	Run: func(cmd *cobra.Command, args []string) {
@@ -46,7 +46,7 @@ func run(confPath string) {
 	serv := keyserver.NewConiksServer(conf)
 
 	// run the server until receiving an interrupt signal
-	serv.Run(conf.TLS)
+	serv.Run(conf.Addresses)
 	ch := make(chan os.Signal, 1)
 	signal.Notify(ch, os.Interrupt)
 	<-ch

--- a/keyserver/listener.go
+++ b/keyserver/listener.go
@@ -11,7 +11,8 @@ import (
 	. "github.com/coniks-sys/coniks-go/protocol"
 )
 
-func (server *ConiksServer) listenForRequests(ln net.Listener, handler func(msg []byte) ([]byte, error)) {
+func (server *ConiksServer) handleRequests(ln net.Listener, tlsConfig *tls.Config,
+	handler func(msg []byte) ([]byte, error)) {
 	defer ln.Close()
 	go func() {
 		<-server.stop
@@ -38,7 +39,7 @@ func (server *ConiksServer) listenForRequests(ln net.Listener, handler func(msg 
 			continue
 		}
 		if _, ok := ln.(*net.TCPListener); ok {
-			conn = tls.Server(conn, server.tlsConfig)
+			conn = tls.Server(conn, tlsConfig)
 		}
 		server.waitCloseConn.Add(1)
 		go func() {

--- a/keyserver/testutil/testutil.go
+++ b/keyserver/testutil/testutil.go
@@ -14,6 +14,7 @@ import (
 	"io/ioutil"
 	"math/big"
 	"net"
+	"net/url"
 	"os"
 	"path"
 	"testing"
@@ -24,8 +25,8 @@ import (
 
 const (
 	TestDir          = "coniksServerTest"
-	PublicConnection = "127.0.0.1:3000"
-	LocalConnection  = "/tmp/conikstest.sock"
+	PublicConnection = "tcp://127.0.0.1:3000"
+	LocalConnection  = "unix:///tmp/conikstest.sock"
 )
 
 type ExpectingDirProofResponse struct {
@@ -123,8 +124,8 @@ func CreateTLSCertForTest(t *testing.T) (string, func()) {
 
 func NewTCPClient(msg []byte) ([]byte, error) {
 	conf := &tls.Config{InsecureSkipVerify: true}
-
-	conn, err := net.Dial("tcp", PublicConnection)
+	u, _ := url.Parse(PublicConnection)
+	conn, err := net.Dial(u.Scheme, u.Host)
 	if err != nil {
 		return nil, err
 	}
@@ -152,10 +153,9 @@ func NewTCPClient(msg []byte) ([]byte, error) {
 }
 
 func NewUnixClient(msg []byte) ([]byte, error) {
-	scheme := "unix"
-	unixaddr := &net.UnixAddr{Name: LocalConnection, Net: scheme}
-
-	conn, err := net.DialUnix(scheme, nil, unixaddr)
+	u, _ := url.Parse(LocalConnection)
+	unixaddr := &net.UnixAddr{Name: u.Path, Net: u.Scheme}
+	conn, err := net.DialUnix(u.Scheme, nil, unixaddr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Which do you prefer:
- Set `LocalAddress` to an empty string to disable the registration bot
- Or, have a `IsUseBot` field in `ServerConfig`?