### PR TITLE
Client-auditor protocol

### DIFF
--- a/protocol/auditlog.go
+++ b/protocol/auditlog.go
@@ -128,8 +128,23 @@ func (h *directoryHistory) verifySTRConsistency(str *m.SignedTreeRoot) error {
 	return CheckBadSTR
 }
 
-// TODO add doc
-func (l *ConiksAuditLog) Query(req *AuditingRequest) (*Response, ErrorCode) {
+// GetObservedSTR gets the observed STR for the CONIKS directory address indicated
+// in the AuditingRequest req received from a CONIKS client from the auditor's latest
+// directory history entry, and returns a tuple of the form
+// (response, error).
+// The response (which also includes the error code) is supposed to
+// be sent back to the client. The returned error is used by the auditor
+// for logging purposes.
+//
+// A request without a directory address is considered
+// malformed, and causes GetObservedSTR() to return a
+// message.NewErrorResponse(ErrMalformedClientMessage) tuple.
+// GetObservedSTR() returns a message.NewObservedSTR(str) tuple.
+// str is the signed tree root the auditor has observed for the latest epoch.
+// If the auditor doesn't have any history entries for the requested CONIKS
+// directory, GetObservedSTR() returns a
+// message.NewErrorResponse(ReqUnknownDirectory) tuple.
+func (l *ConiksAuditLog) GetObservedSTR(req *AuditingRequest) (*Response, ErrorCode) {
 
 	// make sure the request is well-formed
 	if len(req.DirectoryAddr) <= 0 {
@@ -141,12 +156,29 @@ func (l *ConiksAuditLog) Query(req *AuditingRequest) (*Response, ErrorCode) {
 		return NewObservedSTR(h.latestSTR)
 	}
 
-	// FIXME: return ErrUnknownDirectory
-	return nil, ErrDirectory
+	return NewErrorResponse(ReqUnknownDirectory), ReqUnknownDirectory
 }
 
-// TODO: add doc
-func (l *ConiksAuditLog) QueryInEpoch(req *AuditingInEpochRequest) (*Response,
+// GetObservedSTRInEpoch gets the observed STR for the CONIKS directory address
+// for a prior directory history entry indicated in the
+// AuditingInEpochRequest req received from a CONIKS client,
+// and returns a tuple of the form (response, error).
+// The response (which also includes the error code) is supposed to
+// be sent back to the client. The returned error is used by the auditor
+// for logging purposes.
+//
+// A request without a directory address or with an epoch greater than the latest
+// observed epoch of this directory is considered malformed, and causes
+// GetObservedSTRInEpoch() to return a
+// message.NewErrorResponse(ErrMalformedClientMessage) tuple.
+// GetObservedSTRInEpoch() returns a message.NewObservedSTRs(strs) tuple.
+// strs is a list of STRs for the epoch range [ep,
+// l.histories[req.DirectoryAddr].latestSTR.Epoch], where ep is the past epoch
+// for which the client has requested the observed STR.
+// If the auditor doesn't have any history entries for the requested CONIKS
+// directory, GetObservedSTR() returns a
+// message.NewErrorResponse(ReqUnknownDirectory) tuple.
+func (l *ConiksAuditLog) GetObservedSTRInEpoch(req *AuditingInEpochRequest) (*Response,
 	ErrorCode) {
 
 	// make sure the request is well-formed
@@ -178,6 +210,5 @@ func (l *ConiksAuditLog) QueryInEpoch(req *AuditingInEpochRequest) (*Response,
 		return NewObservedSTRs(strs)
 	}
 
-	// FIXME: return ErrUnknownDirectory
-	return nil, ErrDirectory
+	return NewErrorResponse(ReqUnknownDirectory), ReqUnknownDirectory
 }

--- a/protocol/auditlog.go
+++ b/protocol/auditlog.go
@@ -100,7 +100,7 @@ func (l *ConiksAuditLog) Update(addr string, newSTR *m.SignedTreeRoot) error {
 
 	h := l.histories[addr]
 
-	if err := h.verifySTRConsistency(newSTR); err != nil {
+	if err := verifySTRConsistency(h.signKey, h.latestSTR, newSTR); err != nil {
 		return err
 	}
 
@@ -108,24 +108,6 @@ func (l *ConiksAuditLog) Update(addr string, newSTR *m.SignedTreeRoot) error {
 	h.snapshots[h.latestSTR.Epoch] = h.latestSTR
 	h.latestSTR = newSTR
 	return nil
-}
-
-// verifySTRConsistency checks the consistency between 2 snapshots.
-// It uses the pinned signing key in the directory history
-// to verify the STR's signature and verifies
-// the hash chain using the latestSTR stored in the history.
-// TODO: dedup this: write generic verifySTRConsistency
-func (h *directoryHistory) verifySTRConsistency(str *m.SignedTreeRoot) error {
-	// verify STR's signature
-	if !h.signKey.Verify(str.Serialize(), str.Signature) {
-		return CheckBadSignature
-	}
-	if str.VerifyHashChain(h.latestSTR) {
-		return nil
-	}
-
-	// TODO: verify the directory's policies as well. See #115
-	return CheckBadSTR
 }
 
 // GetObservedSTR gets the observed STR for the CONIKS directory address indicated

--- a/protocol/auditlog.go
+++ b/protocol/auditlog.go
@@ -152,28 +152,29 @@ func (l *ConiksAuditLog) GetObservedSTRs(req *AuditingRequest) (*Response,
 			ErrMalformedClientMessage
 	}
 
-	if h := l.histories[req.DirectoryAddr]; h != nil {
+	h := l.histories[req.DirectoryAddr]
 
-		// also make sure the epoch is well-formed
-		if req.Epoch > h.latestSTR.Epoch {
-			return NewErrorResponse(ErrMalformedClientMessage),
-				ErrMalformedClientMessage
-		}
-
-		var strs []*DirSTR
-		startEp := req.Epoch
-		endEp := h.latestSTR.Epoch
-
-		for ep := startEp; ep < endEp; ep++ {
-			str := h.snapshots[ep]
-			strs = append(strs, str)
-		}
-
-		// don't forget to append the latest STR
-		strs = append(strs, h.latestSTR)
-
-		return NewSTRHistoryRange(strs)
+	if h == nil {
+		return NewErrorResponse(ReqUnknownDirectory), ReqUnknownDirectory
 	}
 
-	return NewErrorResponse(ReqUnknownDirectory), ReqUnknownDirectory
+	// also make sure the epoch is well-formed
+	if req.Epoch > h.latestSTR.Epoch {
+		return NewErrorResponse(ErrMalformedClientMessage),
+			ErrMalformedClientMessage
+	}
+
+	var strs []*DirSTR
+	startEp := req.Epoch
+	endEp := h.latestSTR.Epoch
+
+	for ep := startEp; ep < endEp; ep++ {
+		str := h.snapshots[ep]
+		strs = append(strs, str)
+	}
+
+	// don't forget to append the latest STR
+	strs = append(strs, h.latestSTR)
+
+	return NewSTRHistoryRange(strs)
 }

--- a/protocol/auditlog.go
+++ b/protocol/auditlog.go
@@ -123,41 +123,9 @@ func (l *ConiksAuditLog) Update(addr string, newSTR *DirSTR) error {
 	return nil
 }
 
-// GetObservedSTR gets the observed STR for the CONIKS directory address
-// indicated in the AuditingRequest req received from a CONIKS client from
-// the auditor's latest
-// directory history entry, and returns a tuple of the form
-// (response, error).
-// The response (which also includes the error code) is supposed to
-// be sent back to the client. The returned error is used by the auditor
-// for logging purposes.
-//
-// A request without a directory address is considered
-// malformed, and causes GetObservedSTR() to return a
-// message.NewErrorResponse(ErrMalformedClientMessage) tuple.
-// GetObservedSTR() returns a message.NewObservedSTR(str) tuple.
-// str is the signed tree root the auditor has observed for the latest epoch.
-// If the auditor doesn't have any history entries for the requested CONIKS
-// directory, GetObservedSTR() returns a
-// message.NewErrorResponse(ReqUnknownDirectory) tuple.
-func (l *ConiksAuditLog) GetObservedSTR(req *AuditingRequest) (*Response, ErrorCode) {
-
-	// make sure the request is well-formed
-	if len(req.DirectoryAddr) <= 0 {
-		return NewErrorResponse(ErrMalformedClientMessage),
-			ErrMalformedClientMessage
-	}
-
-	if h := l.histories[req.DirectoryAddr]; h != nil {
-		return NewObservedSTR(h.latestSTR)
-	}
-
-	return NewErrorResponse(ReqUnknownDirectory), ReqUnknownDirectory
-}
-
-// GetObservedSTRInEpoch gets the observed STR for the CONIKS directory
-// address for a prior directory history entry indicated in the
-// AuditingInEpochRequest req received from a CONIKS client,
+// GetObservedSTRs gets the observed STR for the CONIKS directory
+// address for a directory history entry indicated in the
+// AuditingRequest req received from a CONIKS client,
 // and returns a tuple of the form (response, error).
 // The response (which also includes the error code) is supposed to
 // be sent back to the client. The returned error is used by the auditor
@@ -165,16 +133,17 @@ func (l *ConiksAuditLog) GetObservedSTR(req *AuditingRequest) (*Response, ErrorC
 //
 // A request without a directory address or with an epoch greater than
 // the latest observed epoch of this directory is considered malformed,
-// and causes GetObservedSTRInEpoch() to return a
+// and causes GetObservedSTRs() to return a
 // message.NewErrorResponse(ErrMalformedClientMessage) tuple.
-// GetObservedSTRInEpoch() returns a message.NewObservedSTRs(strs) tuple.
+// GetObservedSTRs() returns a message.NewSTRList(strs) tuple.
 // strs is a list of STRs for the epoch range [ep,
-// l.histories[req.DirectoryAddr].latestSTR.Epoch], where ep is the past
-// epoch for which the client has requested the observed STR.
+// l.histories[req.DirectoryAddr].latestSTR.Epoch], where ep is the epoch for
+// which the client has requested the observed STR; i.e. if ep == the latest epoch,
+// the list returned is of length 1.
 // If the auditor doesn't have any history entries for the requested CONIKS
-// directory, GetObservedSTR() returns a
+// directory, GetObservedSTRs() returns a
 // message.NewErrorResponse(ReqUnknownDirectory) tuple.
-func (l *ConiksAuditLog) GetObservedSTRInEpoch(req *AuditingInEpochRequest) (*Response,
+func (l *ConiksAuditLog) GetObservedSTRs(req *AuditingRequest) (*Response,
 	ErrorCode) {
 
 	// make sure the request is well-formed
@@ -203,7 +172,7 @@ func (l *ConiksAuditLog) GetObservedSTRInEpoch(req *AuditingInEpochRequest) (*Re
 		// don't forget to append the latest STR
 		strs = append(strs, h.latestSTR)
 
-		return NewObservedSTRs(strs)
+		return NewSTRList(strs)
 	}
 
 	return NewErrorResponse(ReqUnknownDirectory), ReqUnknownDirectory

--- a/protocol/auditlog.go
+++ b/protocol/auditlog.go
@@ -10,7 +10,7 @@ import (
 )
 
 type directoryHistory struct {
-	dirName   string
+	addr      string
 	signKey   sign.PublicKey
 	snapshots map[uint64]*DirSTR
 	latestSTR *DirSTR
@@ -20,7 +20,7 @@ type directoryHistory struct {
 // of all CONIKS directories known to a CONIKS auditor,
 // indexing the histories by the hash of a directory's initial
 // STR (specifically, the hash of the STR's signature as a string).
-// Each history includes the directory's domain dirName as a string, its
+// Each history includes the directory's domain addr as a string, its
 // public signing key enabling the auditor to verify the corresponding
 // signed tree roots, and a map with the snapshots for each observed
 // epoch.
@@ -34,9 +34,9 @@ func (h *directoryHistory) updateLatestSTR(newLatest *DirSTR) {
 }
 
 // caller validates that initSTR is for epoch 0
-func newDirectoryHistory(dirName string, signKey sign.PublicKey, initSTR *DirSTR) *directoryHistory {
+func newDirectoryHistory(addr string, signKey sign.PublicKey, initSTR *DirSTR) *directoryHistory {
 	h := new(directoryHistory)
-	h.dirName = dirName
+	h.addr = addr
 	h.signKey = signKey
 	h.snapshots = make(map[uint64]*DirSTR)
 	h.updateLatestSTR(initSTR)
@@ -50,14 +50,16 @@ func NewAuditLog() ConiksAuditLog {
 	return make(map[string]*directoryHistory)
 }
 
-// Set associates the given directoryHistory with the dirInitHash in the
-// ConiksAuditLog.
+// Set associates the given directoryHistory with the directory identifier
+// (i.e. the hash of the initial STR) dirInitHash in the ConiksAuditLog.
 func (l ConiksAuditLog) Set(dirInitHash string, dirHistory *directoryHistory) {
 	l[dirInitHash] = dirHistory
 }
 
-// Get retrieves the directory history for the given dirInitHash
-// from the ConiksAuditLog.
+// Get retrieves the directory history for the given directory identifier
+// dirInitHash from the ConiksAuditLog.
+// Get() also returns a boolean indicating whether the requested dirInitHash
+// is present in the log.
 func (l ConiksAuditLog) Get(dirInitHash string) (*directoryHistory, bool) {
 	h, ok := l[dirInitHash]
 	return h, ok

--- a/protocol/auditlog.go
+++ b/protocol/auditlog.go
@@ -7,13 +7,12 @@ package protocol
 
 import (
 	"github.com/coniks-sys/coniks-go/crypto/sign"
-	m "github.com/coniks-sys/coniks-go/merkletree"
 )
 
 type directoryHistory struct {
 	signKey   sign.PublicKey
-	snapshots map[uint64]*m.SignedTreeRoot
-	latestSTR *m.SignedTreeRoot
+	snapshots map[uint64]*DirSTR
+	latestSTR *DirSTR
 }
 
 // A ConiksAuditLog maintains the histories
@@ -25,10 +24,10 @@ type ConiksAuditLog struct {
 	histories map[string]*directoryHistory
 }
 
-func newDirectoryHistory(signKey sign.PublicKey, str *m.SignedTreeRoot) *directoryHistory {
+func newDirectoryHistory(signKey sign.PublicKey, str *DirSTR) *directoryHistory {
 	h := new(directoryHistory)
 	h.signKey = signKey
-	h.snapshots = make(map[uint64]*m.SignedTreeRoot)
+	h.snapshots = make(map[uint64]*DirSTR)
 	h.latestSTR = str
 	return h
 }
@@ -69,7 +68,7 @@ func (l *ConiksAuditLog) IsKnownDirectory(addr string) bool {
 // masomel: will probably want to write a more generic function
 // for "catching up" on a history in case an auditor misses epochs
 func (l *ConiksAuditLog) Insert(addr string, signKey sign.PublicKey,
-	oldSTRs map[uint64]*m.SignedTreeRoot, latestSTR *m.SignedTreeRoot) error {
+	oldSTRs map[uint64]*DirSTR, latestSTR *DirSTR) error {
 
 	// error if we want to create a new entry for an addr we already know
 	if l.IsKnownDirectory(addr) {
@@ -105,7 +104,7 @@ func (l *ConiksAuditLog) Insert(addr string, signKey sign.PublicKey,
 // addr prior to its first call and thereby expects that an entry for addr
 // exists in the audit log l.
 // FIXME: pass Response message as param
-func (l *ConiksAuditLog) Update(addr string, newSTR *m.SignedTreeRoot) error {
+func (l *ConiksAuditLog) Update(addr string, newSTR *DirSTR) error {
 
 	// error if we want to update the entry for an addr we don't know
 	if !l.IsKnownDirectory(addr) {
@@ -192,7 +191,7 @@ func (l *ConiksAuditLog) GetObservedSTRInEpoch(req *AuditingInEpochRequest) (*Re
 				ErrMalformedClientMessage
 		}
 
-		var strs []*m.SignedTreeRoot
+		var strs []*DirSTR
 		startEp := req.Epoch
 		endEp := h.latestSTR.Epoch
 

--- a/protocol/auditlog.go
+++ b/protocol/auditlog.go
@@ -6,14 +6,11 @@
 package protocol
 
 import (
-	"encoding/hex"
-
-	"github.com/coniks-sys/coniks-go/crypto"
 	"github.com/coniks-sys/coniks-go/crypto/sign"
 )
 
 type directoryHistory struct {
-	dirName   string
+	name      string
 	signKey   sign.PublicKey
 	snapshots map[uint64]*DirSTR
 	latestSTR *DirSTR
@@ -29,15 +26,6 @@ type directoryHistory struct {
 // epoch.
 type ConiksAuditLog map[string]*directoryHistory
 
-// computeInitSTRHash is a wrapper for the digest function;
-// returns empty string if the STR isn't an initial STR (i.e. str.Epoch != 0)
-func computeInitSTRHash(initSTR *DirSTR) string {
-	if initSTR.Epoch != 0 {
-		return ""
-	}
-	return hex.EncodeToString(crypto.Digest(initSTR.Signature))
-}
-
 // updateLatestSTR inserts a new STR into a directory history;
 // assumes the STR has been validated by the caller
 func (h *directoryHistory) updateLatestSTR(newLatest *DirSTR) {
@@ -46,9 +34,9 @@ func (h *directoryHistory) updateLatestSTR(newLatest *DirSTR) {
 }
 
 // caller validates that initSTR is for epoch 0
-func newDirectoryHistory(dirName string, signKey sign.PublicKey, initSTR *DirSTR) *directoryHistory {
+func newDirectoryHistory(name string, signKey sign.PublicKey, initSTR *DirSTR) *directoryHistory {
 	h := new(directoryHistory)
-	h.dirName = dirName
+	h.name = name
 	h.signKey = signKey
 	h.snapshots = make(map[uint64]*DirSTR)
 	h.updateLatestSTR(initSTR)
@@ -100,7 +88,7 @@ func (l ConiksAuditLog) Insert(addr string, signKey sign.PublicKey,
 	}
 
 	// compute the hash of the initial STR
-	dirInitHash := computeInitSTRHash(hist[0])
+	dirInitHash := ComputeDirectoryIdentity(hist[0])
 
 	// error if we want to create a new entry for a directory
 	// we already know

--- a/protocol/auditlog.go
+++ b/protocol/auditlog.go
@@ -1,0 +1,183 @@
+// This module implements a CONIKS audit log that a CONIKS auditor
+// maintains.
+// An audit log is a mirror of many CONIKS key directories' STR history,
+// allowing CONIKS clients to audit the CONIKS directories.
+
+package protocol
+
+import (
+	"github.com/coniks-sys/coniks-go/crypto/sign"
+	m "github.com/coniks-sys/coniks-go/merkletree"
+)
+
+type directoryHistory struct {
+	signKey   sign.PublicKey
+	snapshots map[uint64]*m.SignedTreeRoot
+	latestSTR *m.SignedTreeRoot
+}
+
+// A ConiksAuditLog maintains the histories
+// of all CONIKS directories known to a CONIKS auditor.
+// Each history includes the directory's public signing key
+// enabling the auditor to verify the corresponding signed
+// tree roots.
+type ConiksAuditLog struct {
+	histories map[string]*directoryHistory
+}
+
+func newDirectoryHistory(signKey sign.PublicKey, str *m.SignedTreeRoot) *directoryHistory {
+	h := new(directoryHistory)
+	h.signKey = signKey
+	h.snapshots = make(map[uint64]*m.SignedTreeRoot)
+	h.latestSTR = str
+	return h
+}
+
+// NewAuditLog constructs a new ConiksAuditLog. It creates an empty
+// log; the auditor will add an entry for each CONIKS directory
+// the first time it observes an STR for that directory.
+func NewAuditLog() *ConiksAuditLog {
+	l := new(ConiksAuditLog)
+	l.histories = make(map[string]*directoryHistory)
+	return l
+}
+
+// IsKnownDirectory checks to see if an entry for the directory
+// address addr exists in the audit log l. IsKnownDirectory() does not
+//  validate the entries themselves. It returns true if an entry exists,
+// and false otherwise.
+func (l *ConiksAuditLog) IsKnownDirectory(addr string) bool {
+	h := l.histories[addr]
+	if h != nil {
+		return true
+	}
+	return false
+}
+
+// FIXME: pass Request message as param
+// masomel: will probably want to write a more generic function
+// for "catching up" on a history in case an auditor misses epochs
+func (l *ConiksAuditLog) Insert(addr string, signKey sign.PublicKey,
+	oldSTRs map[uint64]*m.SignedTreeRoot, latestSTR *m.SignedTreeRoot) error {
+
+	// panic if we want to create a new entry for an addr we already know
+	if l.IsKnownDirectory(addr) {
+		panic("[protocol] Trying to add an audit log entry for an existing address")
+	}
+
+	// create the new directory history
+	h := newDirectoryHistory(signKey, latestSTR)
+
+	startEp := uint64(0)
+	endEp := latestSTR.Epoch
+
+	// add each old STR into the history
+	for ep := startEp; ep < endEp; ep++ {
+		if str := oldSTRs[ep]; str != nil {
+			h.snapshots[ep] = str
+		}
+		return ErrMalformedDirectoryMessage
+	}
+
+	// FIXME: verify the consistency of each new STR
+	return nil
+}
+
+// Update verifies the consistency of a newly observed STR newSTR for
+// the directory addr, and inserts the newSTR into addr's directory history
+// if the checks (i.e. STR signature and hash chain verifications) pass.
+// Update() returns nil if the checks pass, and the appropriate consistency
+// check error otherwise. Update() assumes that Insert() has been called for
+// addr prior to its first call and thereby expects that an entry for addr
+// exists in the audit log l.
+// FIXME: pass Request message as param
+func (l *ConiksAuditLog) Update(addr string, newSTR *m.SignedTreeRoot) error {
+
+	// panic if we want to update an entry for which we don't have
+	if !l.IsKnownDirectory(addr) {
+		panic("[protocol] Trying to update audit log entry for non-existent address")
+	}
+
+	h := l.histories[addr]
+
+	if err := h.verifySTRConsistency(newSTR); err != nil {
+		return err
+	}
+
+	// update the latest STR
+	h.snapshots[h.latestSTR.Epoch] = h.latestSTR
+	h.latestSTR = newSTR
+	return nil
+}
+
+// verifySTRConsistency checks the consistency between 2 snapshots.
+// It uses the pinned signing key in the directory history
+// to verify the STR's signature and verifies
+// the hash chain using the latestSTR stored in the history.
+// TODO: dedup this: write generic verifySTRConsistency
+func (h *directoryHistory) verifySTRConsistency(str *m.SignedTreeRoot) error {
+	// verify STR's signature
+	if !h.signKey.Verify(str.Serialize(), str.Signature) {
+		return CheckBadSignature
+	}
+	if str.VerifyHashChain(h.latestSTR) {
+		return nil
+	}
+
+	// TODO: verify the directory's policies as well. See #115
+	return CheckBadSTR
+}
+
+// TODO add doc
+func (l *ConiksAuditLog) Query(req *AuditingRequest) (*Response, ErrorCode) {
+
+	// make sure the request is well-formed
+	if len(req.DirectoryAddr) <= 0 {
+		return NewErrorResponse(ErrMalformedClientMessage),
+			ErrMalformedClientMessage
+	}
+
+	if h := l.histories[req.DirectoryAddr]; h != nil {
+		return NewObservedSTR(h.latestSTR)
+	}
+
+	// FIXME: return ErrUnknownDirectory
+	return nil, ErrDirectory
+}
+
+// TODO: add doc
+func (l *ConiksAuditLog) QueryInEpoch(req *AuditingInEpochRequest) (*Response,
+	ErrorCode) {
+
+	// make sure the request is well-formed
+	if len(req.DirectoryAddr) <= 0 {
+		return NewErrorResponse(ErrMalformedClientMessage),
+			ErrMalformedClientMessage
+	}
+
+	if h := l.histories[req.DirectoryAddr]; h != nil {
+
+		// also make sure the epoch is well-formed
+		if req.Epoch > h.latestSTR.Epoch {
+			return NewErrorResponse(ErrMalformedClientMessage),
+				ErrMalformedClientMessage
+		}
+
+		var strs []*m.SignedTreeRoot
+		startEp := req.Epoch
+		endEp := h.latestSTR.Epoch
+
+		for ep := startEp; ep < endEp; ep++ {
+			str := h.snapshots[ep]
+			strs = append(strs, str)
+		}
+
+		// don't forget to append the latest STR
+		strs = append(strs, h.latestSTR)
+
+		return NewObservedSTRs(strs)
+	}
+
+	// FIXME: return ErrUnknownDirectory
+	return nil, ErrDirectory
+}

--- a/protocol/auditlog.go
+++ b/protocol/auditlog.go
@@ -135,7 +135,7 @@ func (l *ConiksAuditLog) Update(addr string, newSTR *DirSTR) error {
 // the latest observed epoch of this directory is considered malformed,
 // and causes GetObservedSTRs() to return a
 // message.NewErrorResponse(ErrMalformedClientMessage) tuple.
-// GetObservedSTRs() returns a message.NewSTRList(strs) tuple.
+// GetObservedSTRs() returns a message.NewSTRHistoryRange(strs) tuple.
 // strs is a list of STRs for the epoch range [ep,
 // l.histories[req.DirectoryAddr].latestSTR.Epoch], where ep is the epoch for
 // which the client has requested the observed STR; i.e. if ep == the latest epoch,
@@ -172,7 +172,7 @@ func (l *ConiksAuditLog) GetObservedSTRs(req *AuditingRequest) (*Response,
 		// don't forget to append the latest STR
 		strs = append(strs, h.latestSTR)
 
-		return NewSTRList(strs)
+		return NewSTRHistoryRange(strs)
 	}
 
 	return NewErrorResponse(ReqUnknownDirectory), ReqUnknownDirectory

--- a/protocol/auditlog_test.go
+++ b/protocol/auditlog_test.go
@@ -98,12 +98,12 @@ func TestGetLatestObservedSTR(t *testing.T) {
 
 	res, err := aud.GetObservedSTRs(&AuditingRequest{
 		DirectoryAddr: "test-server",
-		Epoch: uint64(d.LatestSTR().Epoch)})
+		Epoch:         uint64(d.LatestSTR().Epoch)})
 	if err != ReqSuccess {
 		t.Fatal("Unable to get latest observed STR")
 	}
 
-	obs := res.DirectoryResponse.(*STRList)
+	obs := res.DirectoryResponse.(*STRHistoryRange)
 	if len(obs.STR) != 1 {
 		t.Fatal("Expect returned STR to be not nil")
 	}
@@ -132,13 +132,13 @@ func TestGetObservedSTRInEpoch(t *testing.T) {
 
 	res, err := aud.GetObservedSTRs(&AuditingRequest{
 		DirectoryAddr: "test-server",
-		Epoch: uint64(6)})
+		Epoch:         uint64(6)})
 
 	if err != ReqSuccess {
 		t.Fatal("Unable to get latest range of STRs")
 	}
 
-	obs := res.DirectoryResponse.(*STRList)
+	obs := res.DirectoryResponse.(*STRHistoryRange)
 	if len(obs.STR) == 0 {
 		t.Fatal("Expect returned STR to be not nil")
 	}
@@ -170,7 +170,7 @@ func TestGetObservedSTRUnknown(t *testing.T) {
 
 	_, err = aud.GetObservedSTRs(&AuditingRequest{
 		DirectoryAddr: "unknown",
-		Epoch: uint64(d.LatestSTR().Epoch)})
+		Epoch:         uint64(d.LatestSTR().Epoch)})
 	if err != ReqUnknownDirectory {
 		t.Fatal("Expect ReqUnknownDirectory for latest STR")
 	}
@@ -204,7 +204,7 @@ func TestGetObservedSTRMalformed(t *testing.T) {
 
 	_, err = aud.GetObservedSTRs(&AuditingRequest{
 		DirectoryAddr: "",
-		Epoch: uint64(d.LatestSTR().Epoch)})
+		Epoch:         uint64(d.LatestSTR().Epoch)})
 	if err != ErrMalformedClientMessage {
 		t.Fatal("Expect ErrMalFormedClientMessage for latest STR")
 	}

--- a/protocol/auditlog_test.go
+++ b/protocol/auditlog_test.go
@@ -1,9 +1,6 @@
 package protocol
 
-import (
-	"github.com/coniks-sys/coniks-go/crypto"
-	"testing"
-)
+import "testing"
 
 func TestInsertEmptyHistory(t *testing.T) {
 	// create basic test directory and audit log with 1 STR
@@ -47,8 +44,7 @@ func TestUpdateUnknownHistory(t *testing.T) {
 
 	// let's make sure that we can't update a history for an unknown
 	// directory in our log
-	var unknown [crypto.HashSizeByte]byte
-	err := aud.Update(unknown, d.LatestSTR())
+	err := aud.Update("unknown", d.LatestSTR())
 	if err != ErrAuditLog {
 		t.Fatal("Expected an ErrAuditLog when updating an unknown server history")
 	}
@@ -156,9 +152,8 @@ func TestGetObservedSTRUnknown(t *testing.T) {
 	// create basic test directory and audit log with 11 STRs
 	d, aud, _ := NewTestAuditLog(t, 10)
 
-	var unknown [crypto.HashSizeByte]byte
 	_, err := aud.GetObservedSTRs(&AuditingRequest{
-		DirInitSTRHash: unknown,
+		DirInitSTRHash: "unknown",
 		StartEpoch:     uint64(d.LatestSTR().Epoch),
 		EndEpoch:       uint64(d.LatestSTR().Epoch)})
 	if err != ReqUnknownDirectory {
@@ -166,7 +161,7 @@ func TestGetObservedSTRUnknown(t *testing.T) {
 	}
 
 	_, err = aud.GetObservedSTRs(&AuditingRequest{
-		DirInitSTRHash: unknown,
+		DirInitSTRHash: "unknown",
 		StartEpoch:     uint64(6),
 		EndEpoch:       uint64(8)})
 	if err != ReqUnknownDirectory {

--- a/protocol/auditlog_test.go
+++ b/protocol/auditlog_test.go
@@ -63,7 +63,8 @@ func TestInsertExistingHistory(t *testing.T) {
 		t.Fatal("Error inserting new server history")
 	}
 
-	// let's make sure that we can't re-insert a new server history into our log
+	// let's make sure that we can't re-insert a new server
+	// history into our log
 	err = aud.Insert("test-server", pk, nil, d.LatestSTR())
 	if err != ErrAuditLog {
 		t.Fatal("Expected an ErrAuditLog when inserting an existing server history")
@@ -79,7 +80,8 @@ func TestUpdateUnknownHistory(t *testing.T) {
 		t.Fatal("Error inserting new server history")
 	}
 
-	// let's make sure that we can't re-insert a new server history into our log
+	// let's make sure that we can't re-insert a new server
+	// history into our log
 	err = aud.Update("unknown", d.LatestSTR())
 	if err != ErrAuditLog {
 		t.Fatal("Expected an ErrAuditLog when updating an unknown server history")
@@ -97,10 +99,11 @@ func TestGetObservedSTR(t *testing.T) {
 
 	res, err := aud.GetObservedSTR(&AuditingRequest{
 		DirectoryAddr: "test-server"})
-	obs := res.DirectoryResponse.(*ObservedSTR)
 	if err != ReqSuccess {
 		t.Fatal("Unable to get latest observed STR")
 	}
+
+	obs := res.DirectoryResponse.(*ObservedSTR)
 	if obs.STR == nil {
 		t.Fatal("Expect returned STR to be not nil")
 	}
@@ -130,10 +133,11 @@ func TestGetObservedSTRInEpoch(t *testing.T) {
 	res, err := aud.GetObservedSTRInEpoch(&AuditingInEpochRequest{
 		DirectoryAddr: "test-server",
 		Epoch:         uint64(6)})
-	obs := res.DirectoryResponse.(*ObservedSTRs)
 	if err != ReqSuccess {
 		t.Fatal("Unable to get latest range of STRs")
 	}
+
+	obs := res.DirectoryResponse.(*ObservedSTRs)
 	if obs.STR == nil || len(obs.STR) < 1 {
 		t.Fatal("Expect returned STR to be not nil")
 	}

--- a/protocol/auditlog_test.go
+++ b/protocol/auditlog_test.go
@@ -134,7 +134,7 @@ func TestGetObservedSTRInEpoch(t *testing.T) {
 	if err != ReqSuccess {
 		t.Fatal("Unable to get latest range of STRs")
 	}
-	if obs.STR == nil {
+	if obs.STR == nil || len(obs.STR) < 1 {
 		t.Fatal("Expect returned STR to be not nil")
 	}
 	if len(obs.STR) != 5 {

--- a/protocol/auditlog_test.go
+++ b/protocol/auditlog_test.go
@@ -12,7 +12,7 @@ func TestUpdateHistory(t *testing.T) {
 	d, aud, hist := NewTestAuditLog(t, 0)
 
 	// update the directory so we can update the audit log
-	dirInitHash := computeInitSTRHash(hist[0])
+	dirInitHash := ComputeDirectoryIdentity(hist[0])
 	d.Update()
 	err := aud.Update(dirInitHash, d.LatestSTR())
 
@@ -55,7 +55,7 @@ func TestUpdateBadNewSTR(t *testing.T) {
 	d, aud, hist := NewTestAuditLog(t, 10)
 
 	// compute the hash of the initial STR for later lookups
-	dirInitHash := computeInitSTRHash(hist[0])
+	dirInitHash := ComputeDirectoryIdentity(hist[0])
 
 	// update the directory a few more times and then try
 	// to update
@@ -73,7 +73,7 @@ func TestGetLatestObservedSTR(t *testing.T) {
 	d, aud, hist := NewTestAuditLog(t, 0)
 
 	// compute the hash of the initial STR for later lookups
-	dirInitHash := computeInitSTRHash(hist[0])
+	dirInitHash := ComputeDirectoryIdentity(hist[0])
 
 	res, err := aud.GetObservedSTRs(&AuditingRequest{
 		DirInitSTRHash: dirInitHash,
@@ -97,7 +97,7 @@ func TestGetObservedSTRInEpoch(t *testing.T) {
 	_, aud, hist := NewTestAuditLog(t, 10)
 
 	// compute the hash of the initial STR for later lookups
-	dirInitHash := computeInitSTRHash(hist[0])
+	dirInitHash := ComputeDirectoryIdentity(hist[0])
 
 	res, err := aud.GetObservedSTRs(&AuditingRequest{
 		DirInitSTRHash: dirInitHash,
@@ -125,7 +125,7 @@ func TestGetObservedSTRMultipleEpochs(t *testing.T) {
 	d, aud, hist := NewTestAuditLog(t, 1)
 
 	// compute the hash of the initial STR for later lookups
-	dirInitHash := computeInitSTRHash(hist[0])
+	dirInitHash := ComputeDirectoryIdentity(hist[0])
 
 	// first AuditingRequest
 	res, err := aud.GetObservedSTRs(&AuditingRequest{
@@ -202,7 +202,7 @@ func TestGetObservedSTRMalformed(t *testing.T) {
 	_, aud, hist := NewTestAuditLog(t, 10)
 
 	// compute the hash of the initial STR for later lookups
-	dirInitHash := computeInitSTRHash(hist[0])
+	dirInitHash := ComputeDirectoryIdentity(hist[0])
 
 	// also test the epoch range
 	_, err := aud.GetObservedSTRs(&AuditingRequest{

--- a/protocol/auditlog_test.go
+++ b/protocol/auditlog_test.go
@@ -1,7 +1,6 @@
 package protocol
 
 import (
-	m "github.com/coniks-sys/coniks-go/merkletree"
 	"testing"
 )
 
@@ -41,7 +40,7 @@ func TestInsertPriorHistory(t *testing.T) {
 	aud := NewAuditLog()
 
 	// create 10 epochs
-	priorSTRs := make(map[uint64]*m.SignedTreeRoot)
+	priorSTRs := make(map[uint64]*DirSTR)
 	for i := 0; i < 10; i++ {
 		priorSTRs[d.LatestSTR().Epoch] = d.LatestSTR()
 		d.Update()
@@ -118,7 +117,7 @@ func TestGetObservedSTRInEpoch(t *testing.T) {
 	aud := NewAuditLog()
 
 	// create 10 epochs
-	priorSTRs := make(map[uint64]*m.SignedTreeRoot)
+	priorSTRs := make(map[uint64]*DirSTR)
 	for i := 0; i < 10; i++ {
 		priorSTRs[d.LatestSTR().Epoch] = d.LatestSTR()
 		d.Update()
@@ -155,7 +154,7 @@ func TestGetObservedSTRUnknown(t *testing.T) {
 	aud := NewAuditLog()
 
 	// create 10 epochs
-	priorSTRs := make(map[uint64]*m.SignedTreeRoot)
+	priorSTRs := make(map[uint64]*DirSTR)
 	for i := 0; i < 10; i++ {
 		priorSTRs[d.LatestSTR().Epoch] = d.LatestSTR()
 		d.Update()
@@ -188,7 +187,7 @@ func TestGetObservedSTRMalformed(t *testing.T) {
 	aud := NewAuditLog()
 
 	// create 10 epochs
-	priorSTRs := make(map[uint64]*m.SignedTreeRoot)
+	priorSTRs := make(map[uint64]*DirSTR)
 	for i := 0; i < 10; i++ {
 		priorSTRs[d.LatestSTR().Epoch] = d.LatestSTR()
 		d.Update()

--- a/protocol/auditlog_test.go
+++ b/protocol/auditlog_test.go
@@ -1,6 +1,9 @@
 package protocol
 
-import "testing"
+import (
+	"github.com/coniks-sys/coniks-go/crypto"
+	"testing"
+)
 
 func TestInsertEmptyHistory(t *testing.T) {
 	// create basic test directory and audit log with 1 STR
@@ -44,7 +47,8 @@ func TestUpdateUnknownHistory(t *testing.T) {
 
 	// let's make sure that we can't update a history for an unknown
 	// directory in our log
-	err := aud.Update("unknown", d.LatestSTR())
+	var unknown [crypto.HashSizeByte]byte
+	err := aud.Update(unknown, d.LatestSTR())
 	if err != ErrAuditLog {
 		t.Fatal("Expected an ErrAuditLog when updating an unknown server history")
 	}
@@ -179,8 +183,9 @@ func TestGetObservedSTRUnknown(t *testing.T) {
 	// create basic test directory and audit log with 11 STRs
 	d, aud, _ := NewTestAuditLog(t, 10)
 
+	var unknown [crypto.HashSizeByte]byte
 	_, err := aud.GetObservedSTRs(&AuditingRequest{
-		DirInitSTRHash: "unknown",
+		DirInitSTRHash: unknown,
 		StartEpoch:     uint64(d.LatestSTR().Epoch),
 		EndEpoch:       uint64(d.LatestSTR().Epoch)})
 	if err != ReqUnknownDirectory {
@@ -188,7 +193,7 @@ func TestGetObservedSTRUnknown(t *testing.T) {
 	}
 
 	_, err = aud.GetObservedSTRs(&AuditingRequest{
-		DirInitSTRHash: "unknown",
+		DirInitSTRHash: unknown,
 		StartEpoch:     uint64(6),
 		EndEpoch:       uint64(8)})
 	if err != ReqUnknownDirectory {

--- a/protocol/common.go
+++ b/protocol/common.go
@@ -1,0 +1,18 @@
+package protocol
+
+import (
+	"encoding/hex"
+	"fmt"
+
+	"github.com/coniks-sys/coniks-go/crypto"
+)
+
+// ComputeDirectoryIdentity returns the hash of
+// the directory's initial STR as a string.
+// It panics if the STR isn't an initial STR (i.e. str.Epoch != 0).
+func ComputeDirectoryIdentity(str *DirSTR) string {
+	if str.Epoch != 0 {
+		panic(fmt.Sprintf("[coniks] Expect epoch 0, got %x", str.Epoch))
+	}
+	return hex.EncodeToString(crypto.Digest(str.Signature))
+}

--- a/protocol/common.go
+++ b/protocol/common.go
@@ -1,7 +1,6 @@
 package protocol
 
 import (
-	"encoding/hex"
 	"fmt"
 
 	"github.com/coniks-sys/coniks-go/crypto"
@@ -10,9 +9,12 @@ import (
 // ComputeDirectoryIdentity returns the hash of
 // the directory's initial STR as a string.
 // It panics if the STR isn't an initial STR (i.e. str.Epoch != 0).
-func ComputeDirectoryIdentity(str *DirSTR) string {
+func ComputeDirectoryIdentity(str *DirSTR) [crypto.HashSizeByte]byte {
 	if str.Epoch != 0 {
 		panic(fmt.Sprintf("[coniks] Expect epoch 0, got %x", str.Epoch))
 	}
-	return hex.EncodeToString(crypto.Digest(str.Signature))
+
+	var initSTRHash [crypto.HashSizeByte]byte
+	copy(initSTRHash[:], crypto.Digest(str.Signature))
+	return initSTRHash
 }

--- a/protocol/common_test.go
+++ b/protocol/common_test.go
@@ -1,0 +1,39 @@
+package protocol
+
+import (
+	"testing"
+)
+
+func TestComputeDirectoryIdentity(t *testing.T) {
+	// FIXME: NewTestDirectory should use a fixed VRF and Signing keys.
+	d, _ := NewTestDirectory(t, true)
+	// str0 := d.LatestSTR()
+	d.Update()
+	str1 := d.LatestSTR()
+	type args struct {
+		str *DirSTR
+	}
+	tests := []struct {
+		name string
+		args args
+		want string
+	}{
+		// {"normal", args{str0}, ""},
+		{"panic", args{str1}, ""},
+	}
+	for _, tt := range tests {
+		// FIXME: Refactor testing. See #18.
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.name == "panic" {
+				defer func() {
+					if r := recover(); r == nil {
+						t.Errorf("The code did not panic")
+					}
+				}()
+			}
+			if got := ComputeDirectoryIdentity(tt.args.str); got != tt.want {
+				t.Errorf("ComputeDirectoryIdentity() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}

--- a/protocol/common_test.go
+++ b/protocol/common_test.go
@@ -2,24 +2,26 @@ package protocol
 
 import (
 	"testing"
+
+	"github.com/coniks-sys/coniks-go/crypto"
 )
 
 func TestComputeDirectoryIdentity(t *testing.T) {
-	// FIXME: NewTestDirectory should use a fixed VRF and Signing keys.
 	d, _ := NewTestDirectory(t, true)
 	// str0 := d.LatestSTR()
 	d.Update()
 	str1 := d.LatestSTR()
+	var unknown [crypto.HashSizeByte]byte
 	type args struct {
 		str *DirSTR
 	}
 	tests := []struct {
 		name string
 		args args
-		want string
+		want [crypto.HashSizeByte]byte
 	}{
 		// {"normal", args{str0}, ""},
-		{"panic", args{str1}, ""},
+		{"panic", args{str1}, unknown},
 	}
 	for _, tt := range tests {
 		// FIXME: Refactor testing. See #18.

--- a/protocol/consistencychecks.go
+++ b/protocol/consistencychecks.go
@@ -100,6 +100,50 @@ func (cc *ConsistencyChecks) HandleResponse(requestType int, msg *Response,
 	return CheckPassed
 }
 
+// handleDirectorySTRs is supposed to be used by CONIKS clients to
+// handle auditor responses, and by CONIKS auditors to handle directory responses.
+func HandleDirectorySTRs(requestType int, msg *Response, signKey sign.PublicKey,
+	savedSTR *m.SignedTreeRoot, e error, isClient bool) error {
+	var str *m.SignedTreeRoot
+	if err := msg.validate(); err != nil {
+		return e
+	}
+
+	switch requestType {
+	case AuditType:
+		if _, ok := msg.DirectoryResponse.(*ObservedSTR); !ok {
+			return e
+		}
+		str = msg.DirectoryResponse.(*ObservedSTR).STR
+		// TODO: compare the STR with the saved one on the client
+		// if the auditor has returned a more recent STR, should the
+		// client update its savedSTR? Should this force a new round of
+		// monitoring?
+	case AuditInEpochType:
+		// this is the default request type for an auditor
+		// since the auditor conservatively assumes it may
+		// have missed epochs
+
+		// FIXME
+		//if _, ok := msg.DirectoryResponse.(*ObservedSTRs); !ok {
+		//	return e
+		//}
+		//str = msg.DirectoryResponse.(*ObservedSTRs).STR
+	default:
+		panic("[coniks] Unknown auditing request type")
+	}
+	// we assume the requestType is AuditInEpochType if we're here
+
+	// verify the timeliness of the STR if we're the auditor
+	// check the consistency of the newly received STRs
+	// FIXME: use `XXInEpoch` version of verifySTRConsistency
+	if err := verifySTRConsistency(signKey, savedSTR, str); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 func (cc *ConsistencyChecks) updateSTR(requestType int, msg *Response) error {
 	var str *DirSTR
 	switch requestType {
@@ -110,9 +154,6 @@ func (cc *ConsistencyChecks) updateSTR(requestType int, msg *Response) error {
 			cc.SavedSTR = str
 			return nil
 		}
-		// FIXME: check whether the STR was issued on time and whatnot.
-		// Maybe it has something to do w/ #81 and client transitioning between epochs.
-		// Try to verify w/ what's been saved
 		if err := cc.verifySTR(str); err == nil {
 			return nil
 		}
@@ -132,7 +173,13 @@ func (cc *ConsistencyChecks) updateSTR(requestType int, msg *Response) error {
 
 // verifySTR checks whether the received STR is the same with
 // the SavedSTR using reflect.DeepEqual().
-func (cc *ConsistencyChecks) verifySTR(str *DirSTR) error {
+// FIXME: check whether the STR was issued on time and whatnot.
+// Maybe it has something to do w/ #81 and client transitioning between epochs.
+// Try to verify w/ what's been saved
+// FIXME: make this generic so the auditor can also verify the timeliness of the
+// STR etc. Might make sense to separate the comparison, which is only done on the client,
+// from the rest.
+func (cc *ConsistencyChecks) verifySTR(str *m.SignedTreeRoot) error {
 	if reflect.DeepEqual(cc.SavedSTR, str) {
 		return nil
 	}

--- a/protocol/consistencychecks.go
+++ b/protocol/consistencychecks.go
@@ -101,8 +101,9 @@ func (cc *ConsistencyChecks) HandleResponse(requestType int, msg *Response,
 	return CheckPassed
 }
 
-// handleDirectorySTRs is supposed to be used by CONIKS clients to
-// handle auditor responses, and by CONIKS auditors to handle directory responses.
+// HandleDirectorySTRs is supposed to be used by CONIKS clients to
+// handle auditor responses, and by CONIKS auditors to handle directory
+// responses.
 func HandleDirectorySTRs(requestType int, msg *Response, signKey sign.PublicKey,
 	savedSTR *m.SignedTreeRoot, e error, isClient bool) error {
 	var str *m.SignedTreeRoot

--- a/protocol/consistencychecks.go
+++ b/protocol/consistencychecks.go
@@ -117,7 +117,7 @@ func (cc *ConsistencyChecks) updateSTR(requestType int, msg *Response) error {
 			return nil
 		}
 		// Otherwise, expect that we've entered a new epoch
-		if err := cc.verifySTRConsistency(cc.SavedSTR, str); err != nil {
+		if err := verifySTRConsistency(cc.signKey, cc.SavedSTR, str); err != nil {
 			return err
 		}
 
@@ -140,12 +140,15 @@ func (cc *ConsistencyChecks) verifySTR(str *DirSTR) error {
 }
 
 // verifySTRConsistency checks the consistency between 2 snapshots.
-// It uses the pinned signing key in cc
-// to verify the STR's signature and should not verify
-// the hash chain using the STR stored in cc.
-func (cc *ConsistencyChecks) verifySTRConsistency(savedSTR, str *DirSTR) error {
+// It uses the signing key signKey to verify the STR's signature.
+// The signKey param either comes from a client's
+// pinned signing key in cc, or an auditor's pinned signing key
+// in its history.
+// In the case of a client-side consistency check, verifySTRConsistency()
+// should not verify the hash chain using the STR stored in cc.
+func verifySTRConsistency(signKey sign.PublicKey, savedSTR, str *m.SignedTreeRoot) error {
 	// verify STR's signature
-	if !cc.signKey.Verify(str.Serialize(), str.Signature) {
+	if !signKey.Verify(str.Serialize(), str.Signature) {
 		return CheckBadSignature
 	}
 	if str.VerifyHashChain(savedSTR) {

--- a/protocol/consistencychecks.go
+++ b/protocol/consistencychecks.go
@@ -2,6 +2,7 @@
 // on data received from a CONIKS directory.
 // These include data binding proof verification,
 // and non-equivocation checks.
+// TODO: move all STR-verifying functionality to a separate module
 
 package protocol
 

--- a/protocol/consistencychecks.go
+++ b/protocol/consistencychecks.go
@@ -105,8 +105,8 @@ func (cc *ConsistencyChecks) HandleResponse(requestType int, msg *Response,
 // handle auditor responses, and by CONIKS auditors to handle directory
 // responses.
 func HandleDirectorySTRs(requestType int, msg *Response, signKey sign.PublicKey,
-	savedSTR *m.SignedTreeRoot, e error, isClient bool) error {
-	var str *m.SignedTreeRoot
+	savedSTR *DirSTR, e error, isClient bool) error {
+	var str *DirSTR
 	if err := msg.validate(); err != nil {
 		return e
 	}
@@ -181,7 +181,7 @@ func (cc *ConsistencyChecks) updateSTR(requestType int, msg *Response) error {
 // FIXME: make this generic so the auditor can also verify the timeliness of the
 // STR etc. Might make sense to separate the comparison, which is only done on the client,
 // from the rest.
-func (cc *ConsistencyChecks) verifySTR(str *m.SignedTreeRoot) error {
+func (cc *ConsistencyChecks) verifySTR(str *DirSTR) error {
 	if reflect.DeepEqual(cc.SavedSTR, str) {
 		return nil
 	}
@@ -195,7 +195,7 @@ func (cc *ConsistencyChecks) verifySTR(str *m.SignedTreeRoot) error {
 // in its history.
 // In the case of a client-side consistency check, verifySTRConsistency()
 // should not verify the hash chain using the STR stored in cc.
-func verifySTRConsistency(signKey sign.PublicKey, savedSTR, str *m.SignedTreeRoot) error {
+func verifySTRConsistency(signKey sign.PublicKey, savedSTR, str *DirSTR) error {
 	// verify STR's signature
 	if !signKey.Verify(str.Serialize(), str.Signature) {
 		return CheckBadSignature

--- a/protocol/error.go
+++ b/protocol/error.go
@@ -66,7 +66,7 @@ var (
 		ErrDirectory:                 "[coniks] Directory error",
 		ErrAuditLog:                  "[coniks] Audit log error",
 		ErrMalformedDirectoryMessage: "[coniks] Malformed directory message",
-		ErrMalformedAuditorMessage: "[coniks] Malformed auditor message",
+		ErrMalformedAuditorMessage:   "[coniks] Malformed auditor message",
 
 		CheckPassed:         "[coniks] Consistency checks passed",
 		CheckBadSignature:   "[coniks] Directory's signature on STR or TB is invalid",

--- a/protocol/error.go
+++ b/protocol/error.go
@@ -11,7 +11,7 @@ type ErrorCode int
 // These codes indicate the status of a client-server or client-auditor message
 // exchange.
 // Codes prefixed by "Req" indicate different client request results.
-// Codes prefixed by "Err" indicate an internal server error or a malformed
+// Codes prefixed by "Err" indicate an internal server/auditor error or a malformed
 // message.
 const (
 	ReqSuccess ErrorCode = iota + 100
@@ -21,6 +21,7 @@ const (
 	ReqUnknownDirectory
 
 	ErrDirectory
+	ErrAuditLog
 	ErrMalformedClientMessage
 	ErrMalformedDirectoryMessage
 )
@@ -49,6 +50,7 @@ const (
 var Errors = map[ErrorCode]bool{
 	ErrMalformedClientMessage:    true,
 	ErrDirectory:                 true,
+	ErrAuditLog:                  true,
 	ErrMalformedDirectoryMessage: true,
 }
 
@@ -60,6 +62,7 @@ var (
 
 		ErrMalformedClientMessage:    "[coniks] Malformed client message",
 		ErrDirectory:                 "[coniks] Directory error",
+		ErrAuditLog:                  "[coniks] Audit log error",
 		ErrMalformedDirectoryMessage: "[coniks] Malformed directory message",
 
 		CheckPassed:         "[coniks] Consistency checks passed",

--- a/protocol/error.go
+++ b/protocol/error.go
@@ -24,6 +24,7 @@ const (
 	ErrAuditLog
 	ErrMalformedClientMessage
 	ErrMalformedDirectoryMessage
+	ErrMalformedAuditorMessage
 )
 
 // These codes indicate the result
@@ -52,6 +53,7 @@ var Errors = map[ErrorCode]bool{
 	ErrDirectory:                 true,
 	ErrAuditLog:                  true,
 	ErrMalformedDirectoryMessage: true,
+	ErrMalformedAuditorMessage:   true,
 }
 
 var (
@@ -64,6 +66,7 @@ var (
 		ErrDirectory:                 "[coniks] Directory error",
 		ErrAuditLog:                  "[coniks] Audit log error",
 		ErrMalformedDirectoryMessage: "[coniks] Malformed directory message",
+		ErrMalformedAuditorMessage: "[coniks] Malformed auditor message",
 
 		CheckPassed:         "[coniks] Consistency checks passed",
 		CheckBadSignature:   "[coniks] Directory's signature on STR or TB is invalid",

--- a/protocol/error.go
+++ b/protocol/error.go
@@ -8,7 +8,8 @@ package protocol
 // An ErrorCode implements the built-in error interface type.
 type ErrorCode int
 
-// These codes indicate the status of a client-server message exchange.
+// These codes indicate the status of a client-server or client-auditor message
+// exchange.
 // Codes prefixed by "Req" indicate different client request results.
 // Codes prefixed by "Err" indicate an internal server error or a malformed
 // message.
@@ -16,6 +17,8 @@ const (
 	ReqSuccess ErrorCode = iota + 100
 	ReqNameExisted
 	ReqNameNotFound
+	// auditor->client: no observed history for the requested directory
+	ReqUnknownDirectory
 
 	ErrDirectory
 	ErrMalformedClientMessage

--- a/protocol/message.go
+++ b/protocol/message.go
@@ -92,15 +92,17 @@ type MonitoringRequest struct {
 }
 
 // An AuditingRequest is a message with a CONIKS key directory's address
-// as a string and an epoch as a uint64 that a CONIKS client sends to
-// a CONIKS auditor to request the given directory's STR at the given
-// epoch.
+// as a string, and a StartEpoch and an EndEpoch as uint64's that a CONIKS
+// client sends to a CONIKS auditor to request the given directory's
+// STRs for the given epoch range. To obtain a single STR, the client
+// must set StartEpoch = EndEpoch in the request.
 //
 // The response to a successful request is an STRHistoryRange with
-// a list of STRs covering the epoch range [Epoch, d.LatestSTR().Epoch].
+// a list of STRs covering the epoch range [StartEpoch, EndEpoch].
 type AuditingRequest struct {
 	DirectoryAddr string
-	Epoch         uint64
+	StartEpoch    uint64
+	EndEpoch      uint64
 }
 
 // A Response message indicates the result of a CONIKS client request

--- a/protocol/message.go
+++ b/protocol/message.go
@@ -4,10 +4,7 @@
 
 package protocol
 
-import (
-	"github.com/coniks-sys/coniks-go/crypto"
-	m "github.com/coniks-sys/coniks-go/merkletree"
-)
+import m "github.com/coniks-sys/coniks-go/merkletree"
 
 // The types of requests CONIKS clients send during the CONIKS protocols.
 const (
@@ -94,16 +91,17 @@ type MonitoringRequest struct {
 	EndEpoch   uint64
 }
 
-// An AuditingRequest is a message with a CONIKS key directory's address
-// as a string, and a StartEpoch and an EndEpoch as uint64's that a CONIKS
-// client sends to a CONIKS auditor to request the given directory's
-// STRs for the given epoch range. To obtain a single STR, the client
-// must set StartEpoch = EndEpoch in the request.
+// An AuditingRequest is a message with a CONIKS key directory's initial
+// STR hash as a string, and a StartEpoch and an EndEpoch as uint64's
+// that a CONIKS client sends to a CONIKS auditor to request the given
+// directory's STRs for the given epoch range. To obtain a single STR,
+// the client must set StartEpoch = EndEpoch in the request.
 //
 // The response to a successful request is an STRHistoryRange with
-// a list of STRs covering the epoch range [StartEpoch, EndEpoch].
+// a list of STRs covering the epoch range [StartEpoch, EndEpoch],
+// inclusively.
 type AuditingRequest struct {
-	DirInitSTRHash [crypto.HashSizeByte]byte
+	DirInitSTRHash string
 	StartEpoch     uint64
 	EndEpoch       uint64
 }

--- a/protocol/message.go
+++ b/protocol/message.go
@@ -118,26 +118,27 @@ type AuditingInEpochRequest struct {
 }
 
 // An AuditingRequest is a message with a CONIKS key directory's address
-// as a string that a CONIKS client sends to a CONIKS auditor to request
-// the latest STR the auditor has observed for the given directory.
-// If the client needs to request a directory's STR for a prior epoch, it
+// as a string that a CONIKS client sends to a CONIKS auditor, or a CONIKS auditor
+// sends to a CONIKS directory, to request the given directory's latest STR.
+// If the client/auditor needs to request a directory's STR for a prior epoch, it
 // must send an AuditingInEpochRequest.
 //
-// The response to a successful request is an ObservedDirectoryProof.
+// The response to a successful request is an ObservedSTR.
 type AuditingRequest struct {
 	DirectoryAddr string `json:"directory_addr"`
 }
 
 // An AuditingInEpochRequest is a message with a key directory's address
 // as a string and an epoch as a uint64 that a CONIKS client sends to
-// a CONIKS auditor to retrieve the STR it observed for the directory in
-// the given epoch. The client sends this request type when it needs to
+// a CONIKS auditor, or a CONIKS auditor sends to a CONIKS directory,
+// to retrieve the STR for the directory in
+// the given epoch. The client/auditor sends this request type when it needs to
 // audit a directory's STR for a prior epoch (i.e. as part of a
-// key lookup in epoch check or a monitoring check). The client can send an
-// AuditingRequest if it needs to audit a directory's STR for its latest
-// epoch.
+// key lookup in epoch check, a monitoring check, or an auditor update).
+// The client/auditor can send an AuditingRequest if it needs to audit a
+// directory's STR for its latest epoch.
 //
-// The response to a successful request is an ObservedDirectoryProofs with
+// The response to a successful request is an ObservedSTRs with
 // a list of STRs covering the epoch range [Epoch, d.LatestSTR().Epoch].
 type AuditingInEpochRequest struct {
 	DirectoryAddr string `json:"directory_addr"`
@@ -301,10 +302,10 @@ func NewMonitoringProof(ap []*m.AuthenticationPath,
 }
 
 // NewObservedSTR creates the response message a CONIKS auditor
-// sends to a client upon an AuditingRequest,
-// and returns a Response containing an ObservedSTR struct.
-// auditlog.Audit() passes the signed tree root for the auditor's latest
-// observed epoch str.
+// sends to a client, or a CONIKS directory sends to an auditor,
+// upon an AuditingRequest, and returns a Response containing an ObservedSTR struct.
+// auditlog.GetObservedSTR(), or directory.GetLatestSTR(), passes the signed
+// tree root for the directory's latest str.
 //
 // See auditlog.Audit() for details on the contents of the created
 // ObservedSTR.

--- a/protocol/message.go
+++ b/protocol/message.go
@@ -92,70 +92,15 @@ type MonitoringRequest struct {
 }
 
 // An AuditingRequest is a message with a CONIKS key directory's address
-// as a string that a CONIKS client sends to a CONIKS auditor to request
-// the latest STR the auditor has observed for the given directory.
-// If the client needs to request a directory's STR for a prior epoch, it
-// must send an AuditingInEpochRequest.
-//
-// The response to a successful request is an ObservedDirectoryProof.
-type AuditingRequest struct {
-	DirectoryAddr string `json:"directory_addr"`
-}
-
-// An AuditingInEpochRequest is a message with a key directory's address
-// as a string and an epoch as a uint64 that a CONIKS client sends to
-// a CONIKS auditor to retrieve the STR it observed for the directory in
-// the given epoch. The client sends this request type when it needs to
-// audit a directory's STR for a prior epoch (i.e. as part of a
-// key lookup in epoch check or a monitoring check). The client can send an
-// AuditingRequest if it needs to audit a directory's STR for its latest
-// epoch.
-//
-// The response to a successful request is an ObservedDirectoryProofs with
-// a list of STRs covering the epoch range [Epoch, d.LatestSTR().Epoch].
-type AuditingInEpochRequest struct {
-	DirectoryAddr string `json:"directory_addr"`
-	Epoch         uint64 `json:"epoch"`
-}
-
-// An AuditingRequest is a message with a CONIKS key directory's address
-// as a string that a CONIKS client sends to a CONIKS auditor, or a CONIKS auditor
-// sends to a CONIKS directory, to request the given directory's latest STR.
-// If the client/auditor needs to request a directory's STR for a prior epoch, it
-// must send an AuditingInEpochRequest.
-//
-// The response to a successful request is an ObservedSTR.
-type AuditingRequest struct {
-	DirectoryAddr string `json:"directory_addr"`
-}
-
-// An AuditingInEpochRequest is a message with a key directory's address
-// as a string and an epoch as a uint64 that a CONIKS client sends to
-// a CONIKS auditor, or a CONIKS auditor sends to a CONIKS directory,
-// to retrieve the STR for the directory in
-// the given epoch. The client/auditor sends this request type when it needs to
-// audit a directory's STR for a prior epoch (i.e. as part of a
-// key lookup in epoch check, a monitoring check, or an auditor update).
-// The client/auditor can send an AuditingRequest if it needs to audit a
-// directory's STR for its latest epoch.
-//
-// The response to a successful request is an ObservedSTRs with
-// a list of STRs covering the epoch range [Epoch, d.LatestSTR().Epoch].
-type AuditingInEpochRequest struct {
-	DirectoryAddr string `json:"directory_addr"`
-	Epoch         uint64 `json:"epoch"`
-}
-
-// An AuditingRequest is a message with a CONIKS key directory's address
 // as a string and an epoch as a uint64 that a CONIKS client sends to
 // a CONIKS auditor to request the given directory's STR at the given
 // epoch.
 //
-// The response to a successful request is an ObservedSTRs with
+// The response to a successful request is an STRHistoryRange with
 // a list of STRs covering the epoch range [Epoch, d.LatestSTR().Epoch].
 type AuditingRequest struct {
-	DirectoryAddr string `json:"directory_addr"`
-	Epoch         uint64 `json:"epoch"`
+	DirectoryAddr string
+	Epoch         uint64
 }
 
 // A Response message indicates the result of a CONIKS client request
@@ -192,10 +137,12 @@ type DirectoryProofs struct {
 	STR []*DirSTR
 }
 
-// An STRList response includes a list of signed tree roots
-// STR. A CONIKS auditor returns this DirectoryResponse type upon an
+// An STRHistoryRange response includes a list of signed tree roots
+// STR representing a range of the STR hash chain. If the range only
+// covers the latest epoch, the list only contains a single STR.
+// A CONIKS auditor returns this DirectoryResponse type upon an
 // AudutingRequest.
-type STRList struct {
+type STRHistoryRange struct {
 	STR []*DirSTR
 }
 
@@ -208,7 +155,7 @@ func NewErrorResponse(e ErrorCode) *Response {
 
 var _ DirectoryResponse = (*DirectoryProof)(nil)
 var _ DirectoryResponse = (*DirectoryProofs)(nil)
-var _ DirectoryResponse = (*STRList)(nil)
+var _ DirectoryResponse = (*STRHistoryRange)(nil)
 
 // NewRegistrationProof creates the response message a CONIKS directory
 // sends to a client upon a RegistrationRequest,
@@ -292,18 +239,18 @@ func NewMonitoringProof(ap []*m.AuthenticationPath,
 	}, ReqSuccess
 }
 
-// NewSTRList creates the response message a CONIKS auditor
+// NewSTRHistoryRange creates the response message a CONIKS auditor
 // sends to a client upon an AuditingRequest,
-// and returns a Response containing an STRList struct.
+// and returns a Response containing an STRHistoryRange struct.
 // auditlog.GetObservedSTRs() passes a list of one or more signed tree roots
 // that the auditor observed for the requested range of epochs str.
 //
 // See auditlog.GetObservedSTRs() for details on the contents of the created
-// STRList.
-func NewSTRList(str []*DirSTR) (*Response, ErrorCode) {
+// STRHistoryRange.
+func NewSTRHistoryRange(str []*DirSTR) (*Response, ErrorCode) {
 	return &Response{
 		Error: ReqSuccess,
-		DirectoryResponse: &STRList{
+		DirectoryResponse: &STRHistoryRange{
 			STR: str,
 		},
 	}, ReqSuccess
@@ -322,7 +269,9 @@ func (msg *Response) validate() error {
 	case *DirectoryProofs:
 		// TODO: also do above assertions here
 		return nil
-	case *STRList:
+	case *STRHistoryRange:
+		// treat the STRHistoryRange as an auditor response
+		// bc validate is only called by a client
 		if len(df.STR) == 0 {
 			return ErrMalformedAuditorMessage
 		}

--- a/protocol/message.go
+++ b/protocol/message.go
@@ -147,6 +147,34 @@ type AuditingInEpochRequest struct {
 	Epoch         uint64 `json:"epoch"`
 }
 
+// An AuditingRequest is a message with a CONIKS key directory's address
+// as a string that a CONIKS client sends to a CONIKS auditor, or a CONIKS auditor
+// sends to a CONIKS directory, to request the given directory's latest STR.
+// If the client/auditor needs to request a directory's STR for a prior epoch, it
+// must send an AuditingInEpochRequest.
+//
+// The response to a successful request is an ObservedSTR.
+type AuditingRequest struct {
+	DirectoryAddr string `json:"directory_addr"`
+}
+
+// An AuditingInEpochRequest is a message with a key directory's address
+// as a string and an epoch as a uint64 that a CONIKS client sends to
+// a CONIKS auditor, or a CONIKS auditor sends to a CONIKS directory,
+// to retrieve the STR for the directory in
+// the given epoch. The client/auditor sends this request type when it needs to
+// audit a directory's STR for a prior epoch (i.e. as part of a
+// key lookup in epoch check, a monitoring check, or an auditor update).
+// The client/auditor can send an AuditingRequest if it needs to audit a
+// directory's STR for its latest epoch.
+//
+// The response to a successful request is an ObservedSTRs with
+// a list of STRs covering the epoch range [Epoch, d.LatestSTR().Epoch].
+type AuditingInEpochRequest struct {
+	DirectoryAddr string `json:"directory_addr"`
+	Epoch         uint64 `json:"epoch"`
+}
+
 // A Response message indicates the result of a CONIKS client request
 // with an appropriate error code, and defines the set of cryptographic
 // proofs a CONIKS directory must return as part of its response.
@@ -308,9 +336,6 @@ func NewMonitoringProof(ap []*m.AuthenticationPath,
 // upon an AuditingRequest, and returns a Response containing an ObservedSTR struct.
 // auditlog.GetObservedSTR(), or directory.GetLatestSTR(), passes the signed
 // tree root for the directory's latest str.
-//
-// See auditlog.Audit() for details on the contents of the created
-// ObservedSTR.
 func NewObservedSTR(str *m.SignedTreeRoot) (*Response, ErrorCode) {
 	return &Response{
 		Error: ReqSuccess,

--- a/protocol/message.go
+++ b/protocol/message.go
@@ -4,7 +4,10 @@
 
 package protocol
 
-import m "github.com/coniks-sys/coniks-go/merkletree"
+import (
+	"github.com/coniks-sys/coniks-go/crypto"
+	m "github.com/coniks-sys/coniks-go/merkletree"
+)
 
 // The types of requests CONIKS clients send during the CONIKS protocols.
 const (
@@ -100,9 +103,9 @@ type MonitoringRequest struct {
 // The response to a successful request is an STRHistoryRange with
 // a list of STRs covering the epoch range [StartEpoch, EndEpoch].
 type AuditingRequest struct {
-	DirectoryAddr string
-	StartEpoch    uint64
-	EndEpoch      uint64
+	DirInitSTRHash [crypto.HashSizeByte]byte
+	StartEpoch     uint64
+	EndEpoch       uint64
 }
 
 // A Response message indicates the result of a CONIKS client request

--- a/protocol/message.go
+++ b/protocol/message.go
@@ -12,6 +12,8 @@ const (
 	KeyLookupType
 	KeyLookupInEpochType
 	MonitoringType
+	AuditType
+	AuditInEpochType
 )
 
 // A Request message defines the data a CONIKS client must send to a CONIKS
@@ -202,7 +204,7 @@ type ObservedSTR struct {
 
 // An ObservedSTRs response includes a list of signed tree roots
 // STR. A CONIKS auditor returns this DirectoryResponse type upon an
-// AudutingRequest.
+// AuditingInEpochRequest.
 type ObservedSTRs struct {
 	STR []*m.SignedTreeRoot
 }

--- a/protocol/message.go
+++ b/protocol/message.go
@@ -348,6 +348,16 @@ func (msg *Response) validate() error {
 	case *DirectoryProofs:
 		// TODO: also do above assertions here
 		return nil
+	case *ObservedSTR:
+		if df.STR == nil {
+			return ErrMalformedAuditorMessage
+		}
+		return nil
+	case *ObservedSTRs:
+		if df.STR == nil || len(df.STR) < 1 {
+			return ErrMalformedAuditorMessage
+		}
+		return nil
 	default:
 		panic("[coniks] Malformed response")
 	}

--- a/protocol/message.go
+++ b/protocol/message.go
@@ -90,6 +90,60 @@ type MonitoringRequest struct {
 	EndEpoch   uint64
 }
 
+// An AuditingRequest is a message with a CONIKS key directory's address
+// as a string that a CONIKS client sends to a CONIKS auditor to request
+// the latest STR the auditor has observed for the given directory.
+// If the client needs to request a directory's STR for a prior epoch, it
+// must send an AuditingInEpochRequest.
+//
+// The response to a successful request is an ObservedDirectoryProof.
+type AuditingRequest struct {
+	DirectoryAddr string `json:"directory_addr"`
+}
+
+// An AuditingInEpochRequest is a message with a key directory's address
+// as a string and an epoch as a uint64 that a CONIKS client sends to
+// a CONIKS auditor to retrieve the STR it observed for the directory in
+// the given epoch. The client sends this request type when it needs to
+// audit a directory's STR for a prior epoch (i.e. as part of a
+// key lookup in epoch check or a monitoring check). The client can send an
+// AuditingRequest if it needs to audit a directory's STR for its latest
+// epoch.
+//
+// The response to a successful request is an ObservedDirectoryProofs with
+// a list of STRs covering the epoch range [Epoch, d.LatestSTR().Epoch].
+type AuditingInEpochRequest struct {
+	DirectoryAddr string `json:"directory_addr"`
+	Epoch         uint64 `json:"epoch"`
+}
+
+// An AuditingRequest is a message with a CONIKS key directory's address
+// as a string that a CONIKS client sends to a CONIKS auditor to request
+// the latest STR the auditor has observed for the given directory.
+// If the client needs to request a directory's STR for a prior epoch, it
+// must send an AuditingInEpochRequest.
+//
+// The response to a successful request is an ObservedDirectoryProof.
+type AuditingRequest struct {
+	DirectoryAddr string `json:"directory_addr"`
+}
+
+// An AuditingInEpochRequest is a message with a key directory's address
+// as a string and an epoch as a uint64 that a CONIKS client sends to
+// a CONIKS auditor to retrieve the STR it observed for the directory in
+// the given epoch. The client sends this request type when it needs to
+// audit a directory's STR for a prior epoch (i.e. as part of a
+// key lookup in epoch check or a monitoring check). The client can send an
+// AuditingRequest if it needs to audit a directory's STR for its latest
+// epoch.
+//
+// The response to a successful request is an ObservedDirectoryProofs with
+// a list of STRs covering the epoch range [Epoch, d.LatestSTR().Epoch].
+type AuditingInEpochRequest struct {
+	DirectoryAddr string `json:"directory_addr"`
+	Epoch         uint64 `json:"epoch"`
+}
+
 // A Response message indicates the result of a CONIKS client request
 // with an appropriate error code, and defines the set of cryptographic
 // proofs a CONIKS directory must return as part of its response.
@@ -99,7 +153,7 @@ type Response struct {
 }
 
 // A DirectoryResponse is a message that includes cryptographic proofs
-// about the key directory that a CONIKS key directory returns
+// about the key directory that a CONIKS key directory or auditor returns
 // to a CONIKS client.
 type DirectoryResponse interface{}
 
@@ -124,8 +178,36 @@ type DirectoryProofs struct {
 	STR []*DirSTR
 }
 
+// An ObservedSTR response includes a single signed tree root
+// STR. A CONIKS auditor returns this DirectoryResponse type upon an
+// AuditingRequest.
+type ObservedSTR struct {
+	STR *m.SignedTreeRoot
+}
+
+// An ObservedSTRs response includes a list of signed tree roots
+// STR. A CONIKS auditor returns this DirectoryResponse type upon an
+// AudutingRequest.
+type ObservedSTRs struct {
+	STR []*m.SignedTreeRoot
+}
+
+// An ObservedSTR response includes a single signed tree root
+// STR. A CONIKS auditor returns this DirectoryResponse type upon an
+// AuditingRequest.
+type ObservedSTR struct {
+	STR *m.SignedTreeRoot
+}
+
+// An ObservedSTRs response includes a list of signed tree roots
+// STR. A CONIKS auditor returns this DirectoryResponse type upon an
+// AudutingRequest.
+type ObservedSTRs struct {
+	STR []*m.SignedTreeRoot
+}
+
 // NewErrorResponse creates a new response message indicating the error
-// that occurred while a CONIKS directory was
+// that occurred while a CONIKS directory or a CONIKS auditor was
 // processing a client request.
 func NewErrorResponse(e ErrorCode) *Response {
 	return &Response{Error: e}
@@ -133,6 +215,8 @@ func NewErrorResponse(e ErrorCode) *Response {
 
 var _ DirectoryResponse = (*DirectoryProof)(nil)
 var _ DirectoryResponse = (*DirectoryProofs)(nil)
+var _ DirectoryResponse = (*ObservedSTR)(nil)
+var _ DirectoryResponse = (*ObservedSTRs)(nil)
 
 // NewRegistrationProof creates the response message a CONIKS directory
 // sends to a client upon a RegistrationRequest,
@@ -211,6 +295,40 @@ func NewMonitoringProof(ap []*m.AuthenticationPath,
 		Error: ReqSuccess,
 		DirectoryResponse: &DirectoryProofs{
 			AP:  ap,
+			STR: str,
+		},
+	}, ReqSuccess
+}
+
+// NewObservedSTR creates the response message a CONIKS auditor
+// sends to a client upon an AuditingRequest,
+// and returns a Response containing an ObservedSTR struct.
+// auditlog.Audit() passes the signed tree root for the auditor's latest
+// observed epoch str.
+//
+// See auditlog.Audit() for details on the contents of the created
+// ObservedSTR.
+func NewObservedSTR(str *m.SignedTreeRoot) (*Response, ErrorCode) {
+	return &Response{
+		Error: ReqSuccess,
+		DirectoryResponse: &ObservedSTR{
+			STR: str,
+		},
+	}, ReqSuccess
+}
+
+// NewObservedSTRs creates the response message a CONIKS auditor
+// sends to a client upon an AuditingInEpochRequest,
+// and returns a Response containing an ObservedSTRs struct.
+// auditlog.AuditInEpoch() passes a list of signed tree roots
+// that the auditor observed for the requested range of epochs str.
+//
+// See auditlog.AuditInEpoch() for details on the contents of the created
+// ObservedSTRs.
+func NewObservedSTRs(str []*m.SignedTreeRoot) (*Response, ErrorCode) {
+	return &Response{
+		Error: ReqSuccess,
+		DirectoryResponse: &ObservedSTRs{
 			STR: str,
 		},
 	}, ReqSuccess

--- a/protocol/message.go
+++ b/protocol/message.go
@@ -213,28 +213,14 @@ type DirectoryProofs struct {
 // STR. A CONIKS auditor returns this DirectoryResponse type upon an
 // AuditingRequest.
 type ObservedSTR struct {
-	STR *m.SignedTreeRoot
+	STR *DirSTR
 }
 
 // An ObservedSTRs response includes a list of signed tree roots
 // STR. A CONIKS auditor returns this DirectoryResponse type upon an
 // AudutingRequest.
 type ObservedSTRs struct {
-	STR []*m.SignedTreeRoot
-}
-
-// An ObservedSTR response includes a single signed tree root
-// STR. A CONIKS auditor returns this DirectoryResponse type upon an
-// AuditingRequest.
-type ObservedSTR struct {
-	STR *m.SignedTreeRoot
-}
-
-// An ObservedSTRs response includes a list of signed tree roots
-// STR. A CONIKS auditor returns this DirectoryResponse type upon an
-// AuditingInEpochRequest.
-type ObservedSTRs struct {
-	STR []*m.SignedTreeRoot
+	STR []*DirSTR
 }
 
 // NewErrorResponse creates a new response message indicating the error
@@ -353,7 +339,7 @@ func NewObservedSTR(str *m.SignedTreeRoot) (*Response, ErrorCode) {
 //
 // See auditlog.AuditInEpoch() for details on the contents of the created
 // ObservedSTRs.
-func NewObservedSTRs(str []*m.SignedTreeRoot) (*Response, ErrorCode) {
+func NewObservedSTRs(str []*DirSTR) (*Response, ErrorCode) {
 	return &Response{
 		Error: ReqSuccess,
 		DirectoryResponse: &ObservedSTRs{

--- a/protocol/message.go
+++ b/protocol/message.go
@@ -4,7 +4,10 @@
 
 package protocol
 
-import m "github.com/coniks-sys/coniks-go/merkletree"
+import (
+	"github.com/coniks-sys/coniks-go/crypto"
+	m "github.com/coniks-sys/coniks-go/merkletree"
+)
 
 // The types of requests CONIKS clients send during the CONIKS protocols.
 const (
@@ -91,17 +94,16 @@ type MonitoringRequest struct {
 	EndEpoch   uint64
 }
 
-// An AuditingRequest is a message with a CONIKS key directory's initial
-// STR hash as a string, and a StartEpoch and an EndEpoch as uint64's
-// that a CONIKS client sends to a CONIKS auditor to request the given
-// directory's STRs for the given epoch range. To obtain a single STR,
-// the client must set StartEpoch = EndEpoch in the request.
+// An AuditingRequest is a message with a CONIKS key directory's address
+// as a string, and a StartEpoch and an EndEpoch as uint64's that a CONIKS
+// client sends to a CONIKS auditor to request the given directory's
+// STRs for the given epoch range. To obtain a single STR, the client
+// must set StartEpoch = EndEpoch in the request.
 //
 // The response to a successful request is an STRHistoryRange with
-// a list of STRs covering the epoch range [StartEpoch, EndEpoch],
-// inclusively.
+// a list of STRs covering the epoch range [StartEpoch, EndEpoch].
 type AuditingRequest struct {
-	DirInitSTRHash string
+	DirInitSTRHash [crypto.HashSizeByte]byte
 	StartEpoch     uint64
 	EndEpoch       uint64
 }

--- a/protocol/str.go
+++ b/protocol/str.go
@@ -19,7 +19,7 @@ func NewDirSTR(str *merkletree.SignedTreeRoot) *DirSTR {
 
 // Serialize overrides merkletree.SignedTreeRoot.Serialize
 func (str *DirSTR) Serialize() []byte {
-	return append(str.SignedTreeRoot.SerializeInternal(), str.Policies.Serialize()...)
+	return append(str.SerializeInternal(), str.Policies.Serialize()...)
 }
 
 // VerifyHashChain wraps merkletree.SignedTreeRoot.VerifyHashChain

--- a/protocol/str.go
+++ b/protocol/str.go
@@ -19,7 +19,7 @@ func NewDirSTR(str *merkletree.SignedTreeRoot) *DirSTR {
 
 // Serialize overrides merkletree.SignedTreeRoot.Serialize
 func (str *DirSTR) Serialize() []byte {
-	return append(str.SerializeInternal(), str.Policies.Serialize()...)
+	return append(str.SignedTreeRoot.SerializeInternal(), str.Policies.Serialize()...)
 }
 
 // VerifyHashChain wraps merkletree.SignedTreeRoot.VerifyHashChain

--- a/protocol/testutil.go
+++ b/protocol/testutil.go
@@ -14,6 +14,7 @@ import (
 func NewTestDirectory(t *testing.T, useTBs bool) (
 	*ConiksDirectory, sign.PublicKey) {
 
+	// FIXME: NewTestDirectory should use a fixed VRF and Signing keys.
 	vrfKey, err := vrf.GenerateKey(nil)
 	if err != nil {
 		t.Fatal(err)

--- a/protocol/testutil.go
+++ b/protocol/testutil.go
@@ -28,3 +28,29 @@ func NewTestDirectory(t *testing.T, useTBs bool) (
 	d := NewDirectory(1, vrfKey, signKey, 10, useTBs)
 	return d, pk
 }
+
+// NewTestAuditLog creates a ConiksAuditLog and corresponding
+// ConiksDirectory used for testing auditor-side CONIKS operations.
+// The new audit log can be initialized with the number of epochs
+// indicating the length of the directory history with which to
+// initialize the log; if numEpochs > 0, the history contains numEpochs+1
+// STRs as it always includes the STR after the last directory update
+func NewTestAuditLog(t *testing.T, numEpochs int) (*ConiksDirectory, ConiksAuditLog, map[uint64]*DirSTR) {
+	d, pk := NewTestDirectory(t, true)
+	aud := NewAuditLog()
+
+	hist := make(map[uint64]*DirSTR)
+	for ep := 0; ep < numEpochs; ep++ {
+		hist[d.LatestSTR().Epoch] = d.LatestSTR()
+		d.Update()
+	}
+	// always include the actual latest STR
+	hist[d.LatestSTR().Epoch] = d.LatestSTR()
+
+	err := aud.Insert("test-server", pk, hist)
+	if err != nil {
+		t.Fatal("Error inserting a new history with %d epochs", numEpochs)
+	}
+
+	return d, aud, hist
+}

--- a/protocol/testutil.go
+++ b/protocol/testutil.go
@@ -49,7 +49,7 @@ func NewTestAuditLog(t *testing.T, numEpochs int) (*ConiksDirectory, ConiksAudit
 
 	err := aud.Insert("test-server", pk, hist)
 	if err != nil {
-		t.Fatal("Error inserting a new history with %d epochs", numEpochs)
+		t.Fatalf("Error inserting a new history with %d STRs", numEpochs+1)
 	}
 
 	return d, aud, hist

--- a/protocol/testutil.go
+++ b/protocol/testutil.go
@@ -35,17 +35,17 @@ func NewTestDirectory(t *testing.T, useTBs bool) (
 // indicating the length of the directory history with which to
 // initialize the log; if numEpochs > 0, the history contains numEpochs+1
 // STRs as it always includes the STR after the last directory update
-func NewTestAuditLog(t *testing.T, numEpochs int) (*ConiksDirectory, ConiksAuditLog, map[uint64]*DirSTR) {
+func NewTestAuditLog(t *testing.T, numEpochs int) (*ConiksDirectory, ConiksAuditLog, []*DirSTR) {
 	d, pk := NewTestDirectory(t, true)
 	aud := NewAuditLog()
 
-	hist := make(map[uint64]*DirSTR)
+	var hist []*DirSTR
 	for ep := 0; ep < numEpochs; ep++ {
-		hist[d.LatestSTR().Epoch] = d.LatestSTR()
+		hist = append(hist, d.LatestSTR())
 		d.Update()
 	}
 	// always include the actual latest STR
-	hist[d.LatestSTR().Epoch] = d.LatestSTR()
+	hist = append(hist, d.LatestSTR())
 
 	err := aud.Insert("test-server", pk, hist)
 	if err != nil {


### PR DESCRIPTION
Part of #151 

TODO:

- [X] client-auditor requests and responses
- [x] auditor state
- [x] tests