### PR TITLE
Pin key server initial STR, load in client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ language: go
 go:
   - "1.9"
   - "1.10"
-  - tip
+# Temporarily stop testing for Go tip due to unknown go fmt error - tip
 
 # TODO: Run `dep ensure` in Travis
 # see: https://github.com/coniks-sys/coniks-go/pull/201

--- a/application/client/config.go
+++ b/application/client/config.go
@@ -3,6 +3,7 @@ package client
 import (
 	"github.com/coniks-sys/coniks-go/application"
 	"github.com/coniks-sys/coniks-go/crypto/sign"
+	"github.com/coniks-sys/coniks-go/protocol"
 )
 
 // Config contains the client's configuration needed to send a request to a
@@ -15,8 +16,10 @@ import (
 // for all request types.
 type Config struct {
 	SignPubkeyPath string `toml:"sign_pubkey_path"`
+	SigningPubKey  sign.PublicKey
 
-	SigningPubKey sign.PublicKey
+	InitSTRPath string `toml:"init_str_path"`
+	InitSTR     *protocol.DirSTR
 
 	RegAddress string `toml:"registration_address,omitempty"`
 	Address    string `toml:"address"`
@@ -27,9 +30,11 @@ var _ application.AppConfig = (*Config)(nil)
 // NewConfig initializes a new client configuration with the given
 // server signing public key path, registration address, and
 // server address.
-func NewConfig(signPubkeyPath, regAddr, serverAddr string) *Config {
+func NewConfig(signPubkeyPath, initSTRPath, regAddr,
+	serverAddr string) *Config {
 	var conf = Config{
 		SignPubkeyPath: signPubkeyPath,
+		InitSTRPath:    initSTRPath,
 		RegAddress:     regAddr,
 		Address:        serverAddr,
 	}
@@ -52,6 +57,13 @@ func (conf *Config) Load(file string) error {
 		return err
 	}
 	conf.SigningPubKey = signPubKey
+
+	// load initial STR
+	initSTR, err := application.LoadInitSTR(conf.InitSTRPath, file)
+	if err != nil {
+		return err
+	}
+	conf.InitSTR = initSTR
 
 	return nil
 }

--- a/application/config.go
+++ b/application/config.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
+	"github.com/BurntSushi/toml"
 	"github.com/coniks-sys/coniks-go/crypto/sign"
 	"github.com/coniks-sys/coniks-go/protocol"
 	"github.com/coniks-sys/coniks-go/utils"

--- a/application/config.go
+++ b/application/config.go
@@ -2,11 +2,13 @@ package application
 
 import (
 	"bytes"
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 
 	"github.com/BurntSushi/toml"
 	"github.com/coniks-sys/coniks-go/crypto/sign"
+	"github.com/coniks-sys/coniks-go/protocol"
 	"github.com/coniks-sys/coniks-go/utils"
 )
 
@@ -31,6 +33,26 @@ func LoadSigningPubKey(path, file string) (sign.PublicKey, error) {
 		return nil, fmt.Errorf("Signing public-key must be 32 bytes (got %d)", len(signPubKey))
 	}
 	return signPubKey, nil
+}
+
+// LoadIinitSTR loads an initial STR at the given path
+// specified in the given config file.
+// If there is any parsing error or the STR is malformed,
+// LoadInitSTR() returns an error with a nil STR.
+func LoadInitSTR(path, file string) (*protocol.DirSTR, error) {
+	initSTRPath := utils.ResolvePath(path, file)
+	initSTRBytes, err := ioutil.ReadFile(initSTRPath)
+	if err != nil {
+		return nil, fmt.Errorf("Cannot read init STR: %v", err)
+	}
+	initSTR := new(protocol.DirSTR)
+	if err := json.Unmarshal(initSTRBytes, &initSTR); err != nil {
+		return nil, fmt.Errorf("Cannot parse initial STR: %v", err)
+	}
+	if initSTR.Epoch != 0 {
+		return nil, fmt.Errorf("Initial STR epoch must be 0 (got %d)", initSTR.Epoch)
+	}
+	return initSTR, nil
 }
 
 // LoadConfig loads an application configuration from the given toml-encoded

--- a/application/config.go
+++ b/application/config.go
@@ -35,7 +35,7 @@ func LoadSigningPubKey(path, file string) (sign.PublicKey, error) {
 	return signPubKey, nil
 }
 
-// LoadIinitSTR loads an initial STR at the given path
+// LoadInitSTR loads an initial STR at the given path
 // specified in the given config file.
 // If there is any parsing error or the STR is malformed,
 // LoadInitSTR() returns an error with a nil STR.
@@ -53,6 +53,20 @@ func LoadInitSTR(path, file string) (*protocol.DirSTR, error) {
 		return nil, fmt.Errorf("Initial STR epoch must be 0 (got %d)", initSTR.Epoch)
 	}
 	return initSTR, nil
+}
+
+// SaveSTR serializes the given STR to the given file.
+func SaveSTR(file string, str *protocol.DirSTR) error {
+	strBytes, err := json.Marshal(str)
+	if err != nil {
+		return err
+	}
+
+	if err := utils.WriteFile(file, strBytes, 0600); err != nil {
+		return err
+	}
+
+	return nil
 }
 
 // LoadConfig loads an application configuration from the given toml-encoded

--- a/application/encoding.go
+++ b/application/encoding.go
@@ -8,7 +8,6 @@ import (
 	"encoding/json"
 
 	"github.com/coniks-sys/coniks-go/protocol"
-	"github.com/coniks-sys/coniks-go/utils"
 )
 
 // MarshalRequest returns a JSON encoding of the client's request.

--- a/application/encoding.go
+++ b/application/encoding.go
@@ -8,6 +8,7 @@ import (
 	"encoding/json"
 
 	"github.com/coniks-sys/coniks-go/protocol"
+	"github.com/coniks-sys/coniks-go/utils"
 )
 
 // MarshalRequest returns a JSON encoding of the client's request.
@@ -115,4 +116,18 @@ func malformedClientMsg(err error) *protocol.Response {
 		err = protocol.ErrMalformedMessage
 	}
 	return protocol.NewErrorResponse(protocol.ErrMalformedMessage)
+}
+
+// MarshalSTRToFile serializes the given STR to the given path.
+func MarshalSTRToFile(str *protocol.DirSTR, path string) error {
+	strBytes, err := json.Marshal(str)
+	if err != nil {
+		return err
+	}
+
+	if err := utils.WriteFile(path, strBytes, 0600); err != nil {
+		return err
+	}
+
+	return nil
 }

--- a/application/encoding.go
+++ b/application/encoding.go
@@ -117,17 +117,3 @@ func malformedClientMsg(err error) *protocol.Response {
 	}
 	return protocol.NewErrorResponse(protocol.ErrMalformedMessage)
 }
-
-// MarshalSTRToFile serializes the given STR to the given path.
-func MarshalSTRToFile(str *protocol.DirSTR, path string) error {
-	strBytes, err := json.Marshal(str)
-	if err != nil {
-		return err
-	}
-
-	if err := utils.WriteFile(path, strBytes, 0600); err != nil {
-		return err
-	}
-
-	return nil
-}

--- a/application/server/config.go
+++ b/application/server/config.go
@@ -20,6 +20,8 @@ type Config struct {
 	LoadedHistoryLength uint64 `toml:"loaded_history_length"`
 	// Policies contains the server's CONIKS policies configuration.
 	Policies *Policies `toml:"policies"`
+	// Path to store the initial STR
+	InitSTRPath string `toml:"init_str_path"`
 	// Addresses contains the server's connections configuration.
 	Addresses []*Address `toml:"addresses"`
 }
@@ -30,7 +32,8 @@ var _ application.AppConfig = (*Config)(nil)
 // server addresses, logger configuration, loaded history length and
 // server application policies.
 func NewConfig(addrs []*Address, logConfig *application.LoggerConfig,
-	loadedHistLen uint64, policies *Policies) *Config {
+	loadedHistLen uint64, policies *Policies,
+	initSTRPath string) *Config {
 	var conf = Config{
 		ServerBaseConfig: &application.ServerBaseConfig{
 			Logger: logConfig,
@@ -38,6 +41,7 @@ func NewConfig(addrs []*Address, logConfig *application.LoggerConfig,
 		LoadedHistoryLength: loadedHistLen,
 		Addresses:           addrs,
 		Policies:            policies,
+		InitSTRPath:         initSTRPath,
 	}
 
 	return &conf

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -6,6 +6,7 @@ import (
 	"github.com/coniks-sys/coniks-go/application"
 	"github.com/coniks-sys/coniks-go/protocol"
 	"github.com/coniks-sys/coniks-go/protocol/directory"
+	"github.com/coniks-sys/coniks-go/utils"
 )
 
 // An Address describes a server's connection.
@@ -67,6 +68,11 @@ func NewConiksServer(conf *Config) *ConiksServer {
 			true),
 		epochTimer: time.NewTimer(time.Duration(conf.Policies.EpochDeadline) * time.Second),
 	}
+
+	// save the initial STR to be used for initializing auditors
+	initSTRPath := utils.ResolvePath(conf.InitSTRPath,
+		conf.ConfigFilePath)
+	application.MarshalSTRToFile(server.dir.LatestSTR(), initSTRPath)
 
 	return server
 }

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -66,8 +66,10 @@ func NewConiksServer(conf *Config) *ConiksServer {
 	}
 
 	// save the initial STR to be used for initializing auditors
-	initSTRPath := utils.ResolvePath(conf.InitSTRPath,
-		conf.ConfigFilePath)
+	// FIXME: this saving should happen in protocol/ (i.e., when the
+	// server starts and updates), because eventually we'll need
+	// persistent storage.
+	initSTRPath := utils.ResolvePath(conf.InitSTRPath, conf.Path)
 	application.SaveSTR(initSTRPath, server.dir.LatestSTR())
 
 	return server

--- a/application/server/server.go
+++ b/application/server/server.go
@@ -72,7 +72,7 @@ func NewConiksServer(conf *Config) *ConiksServer {
 	// save the initial STR to be used for initializing auditors
 	initSTRPath := utils.ResolvePath(conf.InitSTRPath,
 		conf.ConfigFilePath)
-	application.MarshalSTRToFile(server.dir.LatestSTR(), initSTRPath)
+	application.SaveSTR(initSTRPath, server.dir.LatestSTR())
 
 	return server
 }

--- a/cli/coniksclient/internal/cmd/init.go
+++ b/cli/coniksclient/internal/cmd/init.go
@@ -23,7 +23,10 @@ func mkConfigOrExit(cmd *cobra.Command, args []string) {
 	dir := cmd.Flag("dir").Value.String()
 	file := path.Join(dir, "config.toml")
 
+	// FIXME: right now we're passing the initSTR, but we should really
+	// be passing the latest pinned STR here
 	conf := client.NewConfig("../../keyserver/coniksserver/sign.pub",
+		"../../keyserver/coniksserver/init.str",
 		"tcp://127.0.0.1:3000", "tcp://127.0.0.1:3000")
 
 	if err := application.SaveConfig(file, conf); err != nil {

--- a/cli/coniksclient/internal/cmd/init.go
+++ b/cli/coniksclient/internal/cmd/init.go
@@ -22,8 +22,8 @@ func mkConfigOrExit(cmd *cobra.Command, args []string) {
 	dir := cmd.Flag("dir").Value.String()
 	file := path.Join(dir, "config.toml")
 	conf := client.NewConfig(file, "toml", "../coniksserver/sign.pub",
-                           "../../keyserver/coniksserver/init.str",
-                           "tcp://127.0.0.1:3000", "tcp://127.0.0.1:3000")
+		"../../keyserver/coniksserver/init.str",
+		"tcp://127.0.0.1:3000", "tcp://127.0.0.1:3000")
 
 	if err := conf.Save(); err != nil {
 		fmt.Println("Couldn't save config. Error message: [" +

--- a/cli/coniksclient/internal/cmd/run.go
+++ b/cli/coniksclient/internal/cmd/run.go
@@ -42,7 +42,10 @@ func init() {
 func run(cmd *cobra.Command, args []string) {
 	isDebugging, _ := strconv.ParseBool(cmd.Flag("debug").Value.String())
 	conf := loadConfigOrExit(cmd)
-	cc := client.New(nil, true, conf.SigningPubKey)
+
+	// FIXME: right now we're passing the initSTR, but we should really
+	// be passing the latest pinned STR here
+	cc := client.New(conf.InitSTR, true, conf.SigningPubKey)
 
 	state, err := terminal.MakeRaw(int(os.Stdin.Fd()))
 	if err != nil {

--- a/cli/coniksserver/internal/cmd/init.go
+++ b/cli/coniksserver/internal/cmd/init.go
@@ -68,7 +68,6 @@ func mkConfig(dir string) {
 
 	conf := server.NewConfig(file, "toml", addrs, logger, 1000000, policies,
 		"init.str")
-	err := application.SaveConfig(file, conf)
 
 	if err := conf.Save(); err != nil {
 		log.Println(err)

--- a/cli/coniksserver/internal/cmd/init.go
+++ b/cli/coniksserver/internal/cmd/init.go
@@ -66,7 +66,8 @@ func mkConfig(dir string) {
 		SignKeyPath:   "sign.priv",
 	}
 
-	conf := server.NewConfig(addrs, logger, 1000000, policies)
+	conf := server.NewConfig(addrs, logger, 1000000, policies,
+		"init.str")
 	err := application.SaveConfig(file, conf)
 
 	if err != nil {


### PR DESCRIPTION
Addresses #196 

Mechanism:
* Add STR serialization/de-serialization functions
* Serialize the key server's initial STR to disk upon startup
* Add initial STR to client config
* Client is initialized with initial STR specified in config

~~Blocked by #203~~