### PR TITLE
Run dep ensure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,8 +6,6 @@ go:
   - 1.9
   - tip
 
-# TODO: Run `dep ensure` in Travis
-# see: https://github.com/coniks-sys/coniks-go/pull/201
 before_install:
   - go get github.com/mattn/goveralls
   - go get golang.org/x/tools/cmd/cover  

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,9 @@ go:
 # see: https://github.com/coniks-sys/coniks-go/pull/201
 before_install:
   - go get github.com/mattn/goveralls
-  - go get golang.org/x/tools/cmd/cover
+  - go get golang.org/x/tools/cmd/cover  
+  - go get -u github.com/golang/dep/cmd/dep
+  - dep ensure
 
 env:
   global:


### PR DESCRIPTION
You can run dep ensure in travis by running `go get -u github.com/golang/dep/cmd/dep` before `dep ensure`.