### PR TITLE
Use `ioutil.WriteFile` for SaveSTR

### DIFF
--- a/application/config.go
+++ b/application/config.go
@@ -93,7 +93,7 @@ func SaveSTR(file string, str *protocol.DirSTR) error {
 		return err
 	}
 
-	if err := utils.WriteFile(file, strBytes, 0600); err != nil {
+	if err := ioutil.WriteFile(file, strBytes, 0600); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
This is relevant to #209.

Currently, SaveSTR uses `utils.WriteFile`, which causes a new running of the server doesn't rewrite the `init.str` and causes the client reporting mismatched hash chain. To resolve that, we change it to `ioutil.WriteFile`, which ensures that the server writes new initial STR.